### PR TITLE
improved gamma-completeness check implementation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 git clone https://github.com/peterschrammel/cbmc
 cd cbmc
 CBMC=`pwd`
-git checkout f24b105d00acb63f3cbe6a13623307258b08a812
+git checkout f8c51ebc26be795046f9311217ef1a2809306330 
 cd src
 make minisat2-download
 make

--- a/regression/acdl/complete-check4/main.c
+++ b/regression/acdl/complete-check4/main.c
@@ -1,0 +1,11 @@
+int main() {
+  int x, y; //, c;
+  _Bool c;
+  __CPROVER_assume(0 <= x && x <= 3);
+  if(c) 
+    x-=4;
+  else
+    x++;     
+  assert(x<0);
+}
+

--- a/regression/acdl/complete-check4/test.desc
+++ b/regression/acdl/complete-check4/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$

--- a/src/acdl/acdl_domain.h
+++ b/src/acdl/acdl_domain.h
@@ -70,7 +70,7 @@ public:
   meet_irreduciblet split(
     const valuet &value,
     const exprt &meet_irreducible_template,
-    bool upper=false);
+    bool upper=false) const;
   
   std::pair<mp_integer, mp_integer> get_var_bound(const valuet &value, const exprt &expr);
   void normalize(valuet &value);
@@ -84,7 +84,9 @@ public:
   bool is_bottom(const valuet &value) const;
   bool is_top(const valuet &value) const { return value.empty(); }
   bool is_complete(const valuet &value, 
-		   const std::set<symbol_exprt> &symbols) const;
+		   const std::set<symbol_exprt> &symbols, const std::set<symbol_exprt> &ngc, const exprt &exp, valuet &gamma_decvar) const;
+  bool gamma_complete_deduction(const exprt &ssa_conjunction, 
+                               const valuet &value) const;
   unsigned compare(const meet_irreduciblet &a, 
        const meet_irreduciblet &b) const;
   unsigned compare_val_lit(valuet &a, meet_irreduciblet &b);

--- a/src/acdl/acdl_solver.cpp
+++ b/src/acdl/acdl_solver.cpp
@@ -1203,6 +1203,7 @@ property_checkert::resultt acdl_solvert::operator()(
         // in gamma-complete phase
         decisions+=gamma_decvar.size();
         gamma_decvar.clear();
+        print_solver_statistics();
         return property_checkert::FAIL;
         // [TODO] Check if we can exit here
         //result = property_checkert::FAIL;

--- a/src/acdl/acdl_solver.h
+++ b/src/acdl/acdl_solver.h
@@ -44,7 +44,7 @@ public:
   }
 
   property_checkert::resultt operator()(const local_SSAt &SSA,
-					const exprt &assertion, const exprt &additional_constraint);
+					const exprt &assertion, const exprt &additional_constraint, const exprt &assumption);
 
   std::set<exprt> decision_variables;
 
@@ -55,7 +55,12 @@ protected:
   acdl_worklist_baset &worklist; 
   acdl_analyze_conflict_baset &analyzes_conflict;
   std::vector<exprt> dec_not_in_trail;
-
+  // collect all lhs cond variables from assumptions 
+  // statements so that we do not make decisions on those
+  std::string assume_lhs;
+  // collect non-gamma-complete variables
+  acdl_domaint::varst non_gamma_complete_var;
+  std::set<acdl_domaint::statementt> gamma_check_processed; 
   acdl_conflict_grapht conflict_graph;
   unsigned ITERATION_LIMIT=999999; 
   
@@ -90,7 +95,7 @@ protected:
 
   bool disable_generalization;
   void initialize_decision_variables(acdl_domaint::valuet &val);
-  void pre_process(const local_SSAt &SSA, const exprt &assertion);
+  void pre_process(const local_SSAt &SSA, const exprt &assertion, const exprt &assumption);
   void print_solver_statistics();
 };
 

--- a/src/acdl/note
+++ b/src/acdl/note
@@ -1000,9 +1000,32 @@ less precise -- can ACDL recover from precision loss due to cheap transformer.
 Research Question:: Can ACDL recover from cheapsyntactic transformers -- 
 in essence, can ACDL do transformer refinement ?
 
-Queries Meeting with Peter on 6th Dec, 2016
+Queries Meeting with Peter on 13th Dec, 2016
 ===========================================
-1> How to remove bvt value_literals; in acdl_domaint ?
-2>  
+1> Do we flush out the non-gamma complete variables after every gamma-complete check?
+2> do we need the !(x=m) check in gamma-completeness check -- for
+complete-check3, the following scenario arise:
+Val=x:[1,3]
+decision=(x<=2)
+check: (x>2) is still satisfied
+
+3> How do we use the constant propagator in gamma-complete check. This is 
+used at the level of goto_function
+
+4> So, far we have built control path guided decisions by evaluating "potential"
+gamma-complete variables. Can we extend this to property guided decision ? For
+this we need one example where one path fails and the other passes. The decision
+should be made on path that fails. That is efficient gamma-complete check.
+
+5> Caching of templates for the same variables is absolute must. How to do it ?
+Do we create a map of <variable set, template set> so that evertime numerical
+inference is called with the same variable, we loop up the map and generate
+the templates. Is it possible to make a set of symbols as key in a map in c++. 
+
+6> Do we add the decisions and deductions made during the gamma-complete phase 
+to the abstract conflict graph -- for the case, where the result of propagation 
+is UNSAT.
+
+
 
 

--- a/src/acdl/note
+++ b/src/acdl/note
@@ -1026,6 +1026,14 @@ the templates. Is it possible to make a set of symbols as key in a map in c++.
 to the abstract conflict graph -- for the case, where the result of propagation 
 is UNSAT.
 
+7> We use SAT to detemine conjunction(SSA,val) where val is obtained after 
+making concrete deductions in the gamma-complete check phase. If
+conjunction(SSA,val) is SAT, then there is a counterexample. However, if it is 
+UNSAT, can we feedback that information to the conflict graph. Presently, the 
+decision and deductions in gamma-complete phase are not incorporated with the 
+conflict graph. 
 
+8> domain.normalize should handle ID_equality constraints as well, that is 
+(x<=10) and (x==5), it should normalize that to (x<=5) ?
 
 

--- a/src/acdl/template_generator_acdl.cpp
+++ b/src/acdl/template_generator_acdl.cpp
@@ -28,16 +28,12 @@ void template_generator_acdlt::operator()(const local_SSAt &SSA, const symbol_ex
   instantiate_standard_domains(SSA);
 
 #ifdef SHOW_TEMPLATE_VARIABLES
-  //debug() << "Template variables: " << eom;
-  //domaint::output_var_specs(debug(),var_specs,SSA.ns); debug() << eom;
-  std::cout << "Template variables: " << std::endl;
-  domain_ptr->output_var_specs_info(std::cout, var_specs, SSA.ns) << std::endl;
+  debug() << "Template variables: " << eom;
+  domaint::output_var_specs(debug(),var_specs,SSA.ns); debug() << eom;
 #endif  
 #ifdef SHOW_TEMPLATE
-  //debug() << "Template: " << eom;
-  //domain_ptr->output_domain(debug(), SSA.ns); debug() << eom;
-  std::cout << "Template: " << std::endl;
-  domain_ptr->output_domain_info(std::cout, SSA.ns) << std::endl;
+  debug() << "Template: " << eom;
+  domain_ptr->output_domain(debug(), SSA.ns); debug() << eom;
 #endif
 }
 
@@ -56,31 +52,46 @@ Function: template_generator_acdlt::operator()
 void template_generator_acdlt::operator()(const local_SSAt &SSA,
 					  const std::set<symbol_exprt> &vars)
 {
+#ifdef SHOW_TEMPLATE_VARIABLES
   clock_t start, finish;
   start = clock();
-  for(std::set<symbol_exprt>::const_iterator it = vars.begin();
+#endif
+  // Avoid template generation on return_values
+  /*for(std::set<symbol_exprt>::const_iterator it = vars.begin();
       it != vars.end(); ++it)
+  {
+    const irep_idt &name = it->get(ID_identifier);
+    std::string s = id2string(name);
+    size_t found;
+    if ((found = name.find("return_value")) != std::string::npos)
+      tmp_var.insert(*it);
+  }*/
+  for(std::set<symbol_exprt>::const_iterator it = vars.begin();
+      it != vars.end(); ++it) {
+    /*const irep_idt &name = it->get(ID_identifier);
+    std::string s = id2string(name);
+    size_t found;
+    if ((found = s.find("return_value")) != std::string::npos)
+      continue; */
     add_var(*it,true_exprt(),true_exprt(),domaint::OUT,var_specs);
+  }
   
   instantiate_standard_domains(SSA);
+#ifdef SHOW_TEMPLATE_VARIABLES
   finish = clock();
   double time = double(finish - start) / CLOCKS_PER_SEC;
   std::cout << "The total time for template generation is " << time << " s" << std::endl;
+#endif
 
 #ifdef SHOW_TEMPLATE_VARIABLES
-  //debug() << "Template variables: " << eom;
-  //domaint::output_var_specs(debug(),var_specs,SSA.ns); debug() << eom;
   std::cout << "Template variables: " << std::endl;
   domain_ptr->output_var_specs_info(std::cout, var_specs, SSA.ns) << std::endl;
 #endif  
 #ifdef SHOW_TEMPLATE
-  //debug() << "Template: " << eom;
-  //domain_ptr->output_domain(debug(), SSA.ns); debug() << eom;
   std::cout << "Template: " << std::endl;
   domain_ptr->output_domain_info(std::cout, SSA.ns) << std::endl;
 #endif
 }
-
 
 /*******************************************************************\
 

--- a/src/ssa/local_ssa.cpp
+++ b/src/ssa/local_ssa.cpp
@@ -60,6 +60,7 @@ void local_SSAt::build_SSA()
     build_cond(i_it);
     build_guard(i_it);
     build_assertions(i_it);
+    build_assumptions(i_it);
     build_function_call(i_it);
   }
 
@@ -108,6 +109,25 @@ void local_SSAt::get_entry_exit_vars()
     last = goto_function.body.instructions.end(); last--;
   get_globals(last,globals_out,true,true,last->function);
 }
+
+
+/*******************************************************************\
+   Function: local_SSAt::build_assumptions
+   Inputs:
+   Outputs:
+   Purpose: collect assumptions (required for backwards analysis)
+\*******************************************************************/
+
+void local_SSAt::build_assumptions(locationt loc)
+{
+  if(loc->is_assume())
+  {
+    exprt c=read_rhs(loc->guard, loc);
+    (--nodes.end())->assumptions.push_back(c);
+  }
+}
+
+
 
 /*******************************************************************\
 

--- a/src/ssa/local_ssa.h
+++ b/src/ssa/local_ssa.h
@@ -75,7 +75,10 @@ public:
 
     typedef std::vector<exprt> assertionst;
     assertionst assertions;
-    
+
+    typedef std::vector<exprt> assumptionst;
+    assumptionst assumptions;
+
     typedef std::vector<function_application_exprt> function_callst;
     function_callst function_calls;
 
@@ -205,6 +208,7 @@ protected:
   void build_guard(locationt loc);
   void build_function_call(locationt loc);
   void build_assertions(locationt loc);
+  void build_assumptions(locationt loc);
 
   // custom templates
   void collect_custom_templates();

--- a/src/summarizer/preprocessing_util.cpp
+++ b/src/summarizer/preprocessing_util.cpp
@@ -166,7 +166,9 @@ void summarizer_parse_optionst::unwind_goto_into_loop(goto_modelt &goto_model, u
     for(loopst::iterator l_it = loops.begin(); l_it != loops.end(); ++l_it)
     {
       std::vector<goto_programt::targett> iteration_points;
-      unwind(body,l_it->second,l_it->first,k,iteration_points);
+      goto_unwindt goto_unwind;
+      goto_unwind.unwind(body,l_it->second,l_it->first,k,
+             goto_unwindt::PARTIAL,iteration_points);
       assert(iteration_points.size()==2);
       goto_programt::targett t=body.insert_before(l_it->first);
       t->make_goto();

--- a/src/summarizer/summary_checker_acdl.cpp
+++ b/src/summarizer/summary_checker_acdl.cpp
@@ -66,8 +66,9 @@ property_checkert::resultt summary_checker_acdlt::operator()(
       i_it!=goto_program.instructions.end();
       i_it++)
   {
-    if(!i_it->is_assert())
+    /*if(!i_it->is_assert() || !i_it->is_assume())
       continue;
+    */
 
     const source_locationt &location=i_it->source_location;
     irep_idt property_id = location.get_property_id();
@@ -93,6 +94,19 @@ property_checkert::resultt summary_checker_acdlt::operator()(
       loophead_selects.push_back(not_exprt(lsguard));
     }
 
+    // iterate over assumptions
+    exprt::operandst assumptions;
+    for(local_SSAt::nodest::const_iterator n_it = SSA.nodes.begin();
+	            n_it != SSA.nodes.end(); n_it++)
+    {
+      for(local_SSAt::nodet::assumptionst::const_iterator 
+          a_it = n_it->assumptions.begin();
+          a_it != n_it->assumptions.end(); a_it++)
+      {
+        std::cout << "Assumption:: " << from_expr(*a_it) << std::endl;
+        assumptions.push_back(*a_it);
+      }
+    }
     // iterate over assertions
     std::list<local_SSAt::nodest::const_iterator> assertion_nodes;
     SSA.find_nodes(i_it,assertion_nodes);
@@ -111,7 +125,8 @@ property_checkert::resultt summary_checker_acdlt::operator()(
         assertions.push_back(*a_it);
       }
     }
-    //   if(simplify) property=simplify_expr(property, SSA.ns);
+
+    // if(simplify) property=simplify_expr(property, SSA.ns);
     property_map[property_id].location = i_it;
 
     //TODO: make the solver incremental
@@ -165,7 +180,7 @@ property_checkert::resultt summary_checker_acdlt::operator()(
     acdl_solver.set_message_handler(get_message_handler());
     property_map[property_id].result =
       acdl_solver(ssa_db.get(goto_model.goto_functions.entry_point()),
-		  conjunction(assertions), conjunction(loophead_selects));
+		  conjunction(assertions), conjunction(loophead_selects), conjunction(assumptions));
     /*acdl_solver(ssa_db.get(goto_model.goto_functions.entry_point()),
       property, true_exprt());*/
   }


### PR DESCRIPTION
Commit summary:
- Provide handle of assumption variables to ACDL solver
- Avoid decisions on "cond" variables associated with assumption statements
- Improved gamma-completeness check implementation 
   - Identify potential "non-gamma complete" variables by path sensitive analysis 
   - Refine is_complete check by making concrete decisions (eg. x==n) on the set of potential "gamma complete" variables
   - Use SAT for deduction over conjunction of SSA and the refined abstract value
 - Ignore template generation (sum and difference constraints) over same program variables (eg. x#2,x#3)    