### PR TITLE
Generalise proofs using domain operator

### DIFF
--- a/src/acdl/acdl_conflict_graph.cpp
+++ b/src/acdl/acdl_conflict_graph.cpp
@@ -64,6 +64,14 @@ void acdl_conflict_grapht::add_decision
   dec_trail.push_back(exp);
   assign(exp);
   //dlevels[sym_no].push_back(current_level);
+  // this just serves as marker in the reason trail
+  // to annotate the segments in reason trail with 
+  // special decision entries, helper for generalization 
+  indext index;
+  index = std::make_pair(0, 0);
+  prop_infot prop_info;
+  prop_info = std::make_pair(nil_exprt(), index);
+  reason_trail.push_back(prop_info);
 }
 
 /*******************************************************************\
@@ -272,7 +280,8 @@ void acdl_conflict_grapht::dump_trail(const local_SSAt &SSA)
       std::cout << "empty " << std::endl;
     else {
      for(unsigned p=prop_level_begin;p<=prop_level_end-1;p++)
-       std::cout << from_expr(SSA.ns, "", prop_trail[p]) << std::endl; 
+       std::cout << from_expr(SSA.ns, "", prop_trail[p]) << " ,"; 
+     std::cout << std::endl; 
     }
   }
 }

--- a/src/acdl/acdl_conflict_graph.cpp
+++ b/src/acdl/acdl_conflict_graph.cpp
@@ -21,8 +21,13 @@ Function: acdl_conflict_grapht::add_deductions
 
  \*******************************************************************/
 void acdl_conflict_grapht::add_deductions
-  (const local_SSAt &SSA, const acdl_domaint::deductionst &m_ir)
+  (const local_SSAt &SSA, const acdl_domaint::deductionst &m_ir, 
+   const acdl_domaint::meet_irreduciblet &stmt)
 {
+  // Add <stmt, prop_trail_index> to reason trail 
+  prop_infot prop_info;
+  prop_info = std::make_pair(stmt, prop_trail.size());
+  reason_trail.push_back(prop_info);
   // iterate over the deductions
   for(std::vector<acdl_domaint::meet_irreduciblet>::const_iterator it 
 	= m_ir.begin(); it != m_ir.end(); it++)
@@ -34,8 +39,6 @@ void acdl_conflict_grapht::add_deductions
     acdl_domaint::meet_irreduciblet exp = *it; 
     assign(exp);
   }
-  // [TODO] Make it a map of <stmt, prop_trail_index>
-  // reason_trail
 }
 
 /*******************************************************************\

--- a/src/acdl/acdl_conflict_graph.cpp
+++ b/src/acdl/acdl_conflict_graph.cpp
@@ -7,7 +7,7 @@ Author: Rajdeep Mukherjee, Peter Schrammel
 \*******************************************************************/
 
 #include "acdl_conflict_graph.h"
-//#define DEBUG
+#define DEBUG
 
 /*******************************************************************\
 
@@ -19,15 +19,15 @@ Function: acdl_conflict_grapht::add_deductions
 
  Purpose:
 
- \*******************************************************************/
+\*******************************************************************/
 void acdl_conflict_grapht::add_deductions
   (const local_SSAt &SSA, const acdl_domaint::deductionst &m_ir, 
    const acdl_domaint::meet_irreduciblet &stmt)
 {
   // Add <stmt, prop_trail_index> to reason trail 
+  indext index;
   prop_infot prop_info;
-  prop_info = std::make_pair(stmt, prop_trail.size());
-  reason_trail.push_back(prop_info);
+  unsigned begin = prop_trail.size();
   // iterate over the deductions
   for(std::vector<acdl_domaint::meet_irreduciblet>::const_iterator it 
 	= m_ir.begin(); it != m_ir.end(); it++)
@@ -39,6 +39,9 @@ void acdl_conflict_grapht::add_deductions
     acdl_domaint::meet_irreduciblet exp = *it; 
     assign(exp);
   }
+  index = std::make_pair(begin, prop_trail.size());
+  prop_info = std::make_pair(stmt, index);
+  reason_trail.push_back(prop_info);
 }
 
 /*******************************************************************\
@@ -62,7 +65,6 @@ void acdl_conflict_grapht::add_decision
   assign(exp);
   //dlevels[sym_no].push_back(current_level);
 }
-
 
 /*******************************************************************\
 
@@ -257,6 +259,22 @@ void acdl_conflict_grapht::dump_trail(const local_SSAt &SSA)
     }
     search_level=search_level-1;
   }
+  unsigned prop_level_end=0, prop_level_begin=0; 
+  std::cout << "The content of reason trail is " << std::endl;
+  for(int i=0;i<reason_trail.size();i++) {
+    indext ind = reason_trail[i].second;
+    unsigned prop_level_begin = ind.first;
+    unsigned prop_level_end = ind.second;
+     
+    std::cout << "The transformer is " << from_expr(reason_trail[i].first) << std::endl;
+    std::cout << "The deductions are ";
+    if(prop_level_begin == prop_level_end) 
+      std::cout << "empty " << std::endl;
+    else {
+     for(unsigned p=prop_level_begin;p<=prop_level_end-1;p++)
+       std::cout << from_expr(SSA.ns, "", prop_trail[p]) << std::endl; 
+    }
+  }
 }
 
 /*******************************************************************\
@@ -269,7 +287,7 @@ Function: acdl_conflict_grapht::print_output
 
  Purpose:
 
- \*******************************************************************/
+\*******************************************************************/
 void acdl_conflict_grapht::dump_dec_trail(const local_SSAt &SSA)
 {
   std::cout << "Dump the decision trail" << std::endl;

--- a/src/acdl/acdl_conflict_graph.h
+++ b/src/acdl/acdl_conflict_graph.h
@@ -28,7 +28,8 @@ public:
    int current_level;
    typedef std::vector<acdl_domaint::meet_irreduciblet> propagation_trail;
    propagation_trail prop_trail;
-   typedef std::vector<acdl_domaint::meet_irreduciblet> reason_trailt;
+   typedef std::pair<acdl_domaint::meet_irreduciblet, unsigned> prop_infot;
+   typedef std::vector<prop_infot> reason_trailt;
    reason_trailt reason_trail;
    typedef std::vector<acdl_domaint::meet_irreduciblet> decision_trail;
    // indexed by decision level
@@ -55,7 +56,7 @@ public:
    typedef hash_numbering<symbol_exprt, irep_hash> sym_numberingt;
    sym_numberingt numbering_symbol;
   
-   void add_deductions(const local_SSAt &SSA, const acdl_domaint::deductionst &m_ir);
+   void add_deductions(const local_SSAt &SSA, const acdl_domaint::deductionst &m_ir, const acdl_domaint::meet_irreduciblet &stmt);
    void add_decision(const acdl_domaint::meet_irreduciblet &m_ir);
    void assign(acdl_domaint::meet_irreduciblet &exp);
    void to_value(acdl_domaint::valuet &value) const;

--- a/src/acdl/acdl_conflict_graph.h
+++ b/src/acdl/acdl_conflict_graph.h
@@ -28,7 +28,8 @@ public:
    int current_level;
    typedef std::vector<acdl_domaint::meet_irreduciblet> propagation_trail;
    propagation_trail prop_trail;
-   typedef std::pair<acdl_domaint::meet_irreduciblet, unsigned> prop_infot;
+   typedef std::pair<unsigned, unsigned> indext;
+   typedef std::pair<acdl_domaint::meet_irreduciblet, indext> prop_infot;
    typedef std::vector<prop_infot> reason_trailt;
    reason_trailt reason_trail;
    typedef std::vector<acdl_domaint::meet_irreduciblet> decision_trail;

--- a/src/acdl/acdl_domain.cpp
+++ b/src/acdl/acdl_domain.cpp
@@ -7,7 +7,7 @@ Author: Rajdeep Mukherjee, Peter Schrammel
 \*******************************************************************/
 
 
-//#define DEBUG
+#define DEBUG
 
 #ifdef DEBUG
 #include <iostream>

--- a/src/acdl/acdl_domain.cpp
+++ b/src/acdl/acdl_domain.cpp
@@ -125,7 +125,7 @@ void acdl_domaint::operator()(
 {
     
   // assert that new_value subsumes final_value 
-  assert(0);
+  // assert(0);
 }
 
 
@@ -2165,4 +2165,26 @@ bool acdl_domaint::gamma_complete_deduction(const exprt &ssa_conjunction,
   }
   solver->pop_context();
 #endif
+}
+
+/*******************************************************************\
+
+Function: acdl_domaint::operator()
+
+ Inputs:
+
+ Outputs:
+
+ Purpose: operator()
+
+\*******************************************************************/
+
+void acdl_domaint::operator()(
+  const statementt &statement,
+  const varst &vars,
+  const valuet &init_value,
+  const valuet &final_value,
+  valuet &generalized_value)
+{
+  // assert(false);
 }

--- a/src/acdl/acdl_domain.h
+++ b/src/acdl/acdl_domain.h
@@ -45,6 +45,13 @@ public:
 		  valuet &final_value,
 		  valuet &new_value);
   
+  void operator()(
+		  const statementt &statement,
+		  const varst &vars,
+		  const valuet &init_value,
+		  const valuet &final_value,
+		  valuet &generalized_value);
+  
   //project deductions to value
   void to_value(const deductionst &deductions, valuet& value)
   {

--- a/src/acdl/acdl_solver.cpp
+++ b/src/acdl/acdl_solver.cpp
@@ -16,7 +16,7 @@ Author: Rajdeep Mukherjee, Peter Schrammel
 #include <string>
 #include <iostream>
 
-//#define DEBUG
+#define DEBUG
 //#define PER_STATEMENT_LIVE_VAR
 #define LIVE_VAR_OLD_APPROACH
 

--- a/src/acdl/acdl_solver.cpp
+++ b/src/acdl/acdl_solver.cpp
@@ -347,7 +347,7 @@ DEDUCE:
 #endif 
     
     // update implication graph
-    conflict_graph.add_deductions(SSA, deductions);
+    conflict_graph.add_deductions(SSA, deductions, statement);
     propagations++; 
     // update worklist based on variables in the consequent (new_v)
     // - collect variables in new_v
@@ -418,7 +418,7 @@ DEDUCE:
     std::vector<acdl_domaint::meet_irreduciblet> ded;
     exprt e = true_exprt(); 
     ded.push_back(e);
-    conflict_graph.add_deductions(SSA, ded);
+    conflict_graph.add_deductions(SSA, ded, false_exprt());
   }
   unsigned final_size = conflict_graph.prop_trail.size();
   //propagations = propagations + (final_size - init_size);

--- a/src/acdl/acdl_solver.h
+++ b/src/acdl/acdl_solver.h
@@ -65,7 +65,7 @@ protected:
   std::set<acdl_domaint::statementt> gamma_check_processed; 
   acdl_conflict_grapht conflict_graph;
   unsigned ITERATION_LIMIT=999999; 
-  
+  unsigned last_decision_index;  
   // global propagation module
   property_checkert::resultt propagate(const local_SSAt &SSA, const exprt& assertion);
   // propagation for chaotic iteration in Abstract interpretation proof
@@ -93,7 +93,7 @@ protected:
   std::set<symbol_exprt> all_vars;
   void init();
   bool analyze_conflict(const local_SSAt &SSA, const exprt& assertion);
-  void generalize_proof(const local_SSAt &SSA, const exprt& assertion, acdl_domaint::valuet& val);
+  void generalize_proof(const local_SSAt &SSA, const exprt& assertion, acdl_domaint::valuet& val) const;
 
   bool disable_generalization;
   void initialize_decision_variables(acdl_domaint::valuet &val);

--- a/src/domains/tpolyhedra_domain.cpp
+++ b/src/domains/tpolyhedra_domain.cpp
@@ -1022,7 +1022,7 @@ void tpolyhedra_domaint::add_difference_template(const var_specst &var_specs,
       // If v1 and v2 have the same base name, then 
       // do not generate template rows for them
       // [TODO] Temporary
-      //if(id1 == id2) continue;
+      if(id1 == id2) continue;
       // check if variables are from different function (eg. main::x#2, g::x#16)
       /*if(p1 != p2) {
 #ifdef DEBUG      
@@ -1140,7 +1140,7 @@ void tpolyhedra_domaint::add_sum_template(const var_specst &var_specs,
       // If v1 and v2 have the same base name, then 
       // do not generate template rows for them (main::x#20, main::x#21)
       // [TODO] Temporary
-      // if(id1 == id2) continue;
+      if(id1 == id2) continue;
       // check if variables are from different function (eg. main::x#2, g::x#16)
       /*if(p1 != p2) {
 #ifdef DEBUG      


### PR DESCRIPTION
Wrapper for generalising proof for conflicts using domain operator interface 
- Reason trail data structure for storing the implication reasons in the abstract conflict graph
- Current framework can support generalisation up to last decision level