### PR TITLE
Replace object allocation guards in templates by a simple inequality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ matrix:
       compiler: clang
       env: COMPILER=clang++
     - env: NAME="CPP-LINT"
+      before_script: git fetch origin master:master
       script: scripts/run_lint.sh master HEAD
 
 script:

--- a/regression/heap/list_false/test.desc
+++ b/regression/heap/list_false/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
---heap-interval --sympath --inline --no-propagation --k-induction
-^EXIT=10$
+--heap-interval --sympath --inline --no-propagation
+^EXIT=5$
 ^SIGNAL=0$
-^VERIFICATION FAILED$
-^\[main.assertion.1\] : FAILURE
+^VERIFICATION INCONCLUSIVE$
+^\[main.assertion.1\] : UNKNOWN

--- a/regression/heap/list_false_kind/main.c
+++ b/regression/heap/list_false_kind/main.c
@@ -1,0 +1,53 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+extern int __VERIFIER_nondet_int();
+/*
+ * Simple example: build a list with only 1s, then 2s and finally
+ * on 3 (arbitrary length); afterwards, go through it and check
+ * if the the list does have the correct form, and in particular
+ * finishes by a 3.
+ */
+#include <stdlib.h>
+
+void exit(int s) {
+ _EXIT: goto _EXIT;
+}
+
+typedef struct node {
+  int h;
+  struct node *n;
+} *List;
+
+int main() {
+  /* Build a list of the form 1->...->1->2->....->2->3 */
+  List a = (List) malloc(sizeof(struct node));
+  if (a == 0) exit(1);
+  List t;
+  List p = a;
+  while (__VERIFIER_nondet_int()) {
+    p->h = 1;
+    t = (List) malloc(sizeof(struct node));
+    if (t == 0) exit(1);
+    p->n = t;
+    p = p->n;
+  }
+  while (__VERIFIER_nondet_int()) {
+    p->h = 2;
+    t = (List) malloc(sizeof(struct node));
+    if (t == 0) exit(1);
+    p->n = t;
+    p = p->n;
+  }
+  p->h = 3;
+    
+  /* Check it */
+  p = a;
+  while (p->h == 2)
+    p = p->n;
+  while (p->h == 1)
+    p = p->n;
+  if(p->h != 3)
+    ERROR: __VERIFIER_error();
+
+  return 0;
+}

--- a/regression/heap/list_false_kind/test.desc
+++ b/regression/heap/list_false_kind/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--heap-interval --sympath --inline --no-propagation --k-induction
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+^\[main.assertion.1\] : FAILURE

--- a/regression/heap/simple_false/test.desc
+++ b/regression/heap/simple_false/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
---heap-interval --sympath --inline --no-propagation --k-induction
-^EXIT=10$
+--heap-interval --sympath --inline --no-propagation
+^EXIT=5$
 ^SIGNAL=0$
-^VERIFICATION FAILED$
-^\[main.assertion.1\] : FAILURE
+^VERIFICATION INCONCLUSIVE$
+^\[main.assertion.1\] : UNKNOWN

--- a/regression/heap/simple_false_kind/main.c
+++ b/regression/heap/simple_false_kind/main.c
@@ -1,0 +1,45 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+extern int __VERIFIER_nondet_int();
+/*
+ * Simple example: build a list with only 1s and finally a 0 (arbitrary length); 
+ * afterwards, go through it and check if the list does have the correct form, and in particular
+ * finishes by a 0.
+ */
+#include <stdlib.h>
+
+void exit(int s) {
+	_EXIT: goto _EXIT;
+}
+
+typedef struct node {
+  int h;
+  struct node *n;
+} *List;
+
+int main() {
+  /* Build a list of the form 1->...->1->0 */
+  List a = (List) malloc(sizeof(struct node));
+  if (a == 0) exit(1);
+  List t;
+  List p = a;
+  a->h = 2;
+  while (__VERIFIER_nondet_int()) {
+    p->h = 1;
+    t = (List) malloc(sizeof(struct node));
+    if (t == 0) exit(1);
+    p->n = t;
+    p = p->n;
+  }
+  p->h = 2;
+  p->n = 0;
+  p = a;
+  while (p!=0) {
+    if (p->h != 2) {
+      ERROR: __VERIFIER_error();
+    }
+    p = p->n;
+  }
+  return 0;
+}
+

--- a/regression/heap/simple_false_kind/test.desc
+++ b/regression/heap/simple_false_kind/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--heap-interval --sympath --inline --no-propagation --k-induction
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+^\[main.assertion.1\] : FAILURE

--- a/regression/memsafety/simple_false/test.desc
+++ b/regression/memsafety/simple_false/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --heap-interval --sympath --inline --pointer-check --k-induction
 ^EXIT=10$

--- a/regression/memsafety/simple_true/test.desc
+++ b/regression/memsafety/simple_true/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --heap-interval --inline --sympath --pointer-check --no-assertions
 ^EXIT=0$

--- a/src/2ls/preprocessing_util.cpp
+++ b/src/2ls/preprocessing_util.cpp
@@ -795,6 +795,9 @@ void twols_parse_optionst::create_dynobj_instances(
         if(obj.id()!=ID_symbol)
           continue;
 
+        if(obj.get_bool("#concrete"))
+          continue;
+
         if(instance_counts.find(to_symbol_expr(obj))==instance_counts.end())
           continue;
 

--- a/src/domains/strategy_solver_heap_tpolyhedra.h
+++ b/src/domains/strategy_solver_heap_tpolyhedra.h
@@ -37,6 +37,7 @@ public:
       template_generator),
     tpolyhedra_solver(heap_tpolyhedra_domain.polyhedra_domain, _solver, SSA.ns)
   {
+    tpolyhedra_solver.set_message_handler(message_handler);
   }
 
   virtual bool iterate(invariantt &_inv) override;

--- a/src/domains/tpolyhedra_domain.cpp
+++ b/src/domains/tpolyhedra_domain.cpp
@@ -485,6 +485,8 @@ exprt tpolyhedra_domaint::get_row_symb_post_constraint(const rowt &row)
     templ_row.post_guard,
     binary_relation_exprt(templ_row.expr, ID_ge, get_row_symb_value(row)));
   rename(c);
+  c=and_exprt(
+    c, not_exprt(equal_exprt(get_row_symb_value(row), templ_row.expr)));
   return and_exprt(templ_row.aux_expr, c);
 }
 

--- a/src/ssa/assignments.cpp
+++ b/src/ssa/assignments.cpp
@@ -33,7 +33,6 @@ void assignmentst::build_assignment_map(
   {
     // make sure we have the location in the map
     assignment_map[it];
-    allocation_map[it];
 
     // now fill it
     if(it->is_assign())
@@ -45,12 +44,6 @@ void assignmentst::build_assignment_map(
       assign(lhs_symbolic_deref, it, ns);
 
       assign_symbolic_rhs(code_assign.rhs(), it, ns);
-
-      // At allocations site, save newly allocated object(s)
-      if(code_assign.rhs().get_bool("#malloc_result"))
-      {
-        allocate(code_assign.rhs(), it, ns);
-      }
     }
     else if(it->is_assert())
     {
@@ -312,35 +305,4 @@ void assignmentst::output(
 
     out << "\n";
   }
-}
-
-/*******************************************************************\
-
-Function: assignmentst::allocate
-
-  Inputs:
-
- Outputs:
-
- Purpose: Record allocation
-
-\*******************************************************************/
-void assignmentst::allocate(
-  const exprt &expr,
-  const assignmentst::locationt loc,
-  const namespacet &ns)
-{
-  if(expr.id()==ID_symbol && expr.type().get_bool("#dynamic"))
-  {
-    allocation_map[loc].insert(ssa_objectt(expr, ns));
-  }
-  else if(expr.id()==ID_if)
-  {
-    allocate(to_if_expr(expr).true_case(), loc, ns);
-    allocate(to_if_expr(expr).false_case(), loc, ns);
-  }
-  else if(expr.id()==ID_address_of)
-    allocate(to_address_of_expr(expr).object(), loc, ns);
-  else if(expr.id()==ID_typecast)
-    allocate(to_typecast_expr(expr).op(), loc, ns);
 }

--- a/src/ssa/assignments.h
+++ b/src/ssa/assignments.h
@@ -28,8 +28,6 @@ public:
   typedef std::map<locationt, objectst> assignment_mapt;
   assignment_mapt assignment_map;
 
-  assignment_mapt allocation_map;
-
   bool assigns(locationt loc, const ssa_objectt &object) const
   {
     assignment_mapt::const_iterator it=assignment_map.find(loc);
@@ -42,13 +40,6 @@ public:
   {
     assignment_mapt::const_iterator it=assignment_map.find(loc);
     assert(it!=assignment_map.end());
-    return it->second;
-  }
-
-  inline const objectst &get_allocations(locationt loc) const
-  {
-    auto it=allocation_map.find(loc);
-    assert(it!=allocation_map.end());
     return it->second;
   }
 
@@ -86,11 +77,6 @@ protected:
   void assign_symbolic_rhs(
     const exprt &expr,
     const locationt &loc,
-    const namespacet &ns);
-
-  void allocate(
-    const exprt &expr,
-    const locationt loc,
     const namespacet &ns);
 };
 

--- a/src/ssa/assignments.h
+++ b/src/ssa/assignments.h
@@ -28,6 +28,9 @@ public:
   typedef std::map<locationt, objectst> assignment_mapt;
   assignment_mapt assignment_map;
 
+  typedef std::map<std::pair<locationt, ssa_objectt>, exprt> alloc_guards_mapt;
+  alloc_guards_mapt alloc_guards_map;
+
   bool assigns(locationt loc, const ssa_objectt &object) const
   {
     assignment_mapt::const_iterator it=assignment_map.find(loc);
@@ -77,6 +80,12 @@ protected:
   void assign_symbolic_rhs(
     const exprt &expr,
     const locationt &loc,
+    const namespacet &ns);
+
+  void create_alloc_decl(
+    const exprt &expr,
+    const exprt &guard,
+    const locationt loc,
     const namespacet &ns);
 };
 

--- a/src/ssa/dynobj_instance_analysis.cpp
+++ b/src/ssa/dynobj_instance_analysis.cpp
@@ -223,7 +223,14 @@ void dynobj_instance_domaint::transform(
         remove_dereferences(assignment.lhs(), instances);
         add_aliased_dereferences(assignment.lhs(), instances);
 
-        live_pointers[v.symbol_expr()].insert(rhs);
+        // Do not include CPROVER objects
+        // TODO: do it better than check for "malloc" substring
+        if(!(rhs.id()==ID_symbol &&
+             id2string(to_symbol_expr(rhs).get_identifier()).find(
+               "malloc")!=std::string::npos))
+        {
+          live_pointers[v.symbol_expr()].insert(rhs);
+        }
       }
     }
   }

--- a/src/ssa/dynobj_instance_analysis.cpp
+++ b/src/ssa/dynobj_instance_analysis.cpp
@@ -226,8 +226,12 @@ void dynobj_instance_domaint::transform(
         // Do not include CPROVER objects
         // TODO: do it better than check for "malloc" substring
         if(!(rhs.id()==ID_symbol &&
-             id2string(to_symbol_expr(rhs).get_identifier()).find(
-               "malloc")!=std::string::npos))
+          (id2string(to_symbol_expr(rhs).get_identifier()).find(
+               "malloc::")!=std::string::npos ||
+           id2string(to_symbol_expr(rhs).get_identifier()).find(
+             "malloc#")!=std::string::npos ||
+           id2string(to_symbol_expr(rhs).get_identifier()).find(
+             "malloc$")!=std::string::npos)))
         {
           live_pointers[v.symbol_expr()].insert(rhs);
         }

--- a/src/ssa/malloc_ssa.h
+++ b/src/ssa/malloc_ssa.h
@@ -16,6 +16,7 @@ exprt malloc_ssa(
   const side_effect_exprt &,
   const std::string &suffix,
   symbol_tablet &,
+  bool is_concrete,
   bool alloc_concrete);
 
 bool replace_malloc(

--- a/src/ssa/ssa_domain.cpp
+++ b/src/ssa/ssa_domain.cpp
@@ -121,17 +121,6 @@ void ssa_domaint::transform(
       def_entry.def.kind=deft::ASSIGNMENT;
       def_entry.source=from;
     }
-
-    auto allocations=
-      static_cast<ssa_ait &>(ai).assignments.get_allocations(from);
-    for(auto &alloc : allocations)
-    {
-      irep_idt identifier=alloc.get_identifier();
-      def_entryt &def_entry=def_map[identifier];
-      def_entry.def.loc=from;
-      def_entry.def.kind=deft::ALLOCATION;
-      def_entry.source=from;
-    }
   }
   else if(from->is_dead())
   {
@@ -221,43 +210,6 @@ bool ssa_domaint::merge(
     }
     else
     {
-      // Do not create PHIs for allocations
-      if(d_it_a->second.def.kind==deft::ALLOCATION ||
-         d_it_b->second.def.kind==deft::ALLOCATION)
-        continue;
-
-      // Do not create PHIs for join of PHI and allocation with assignment
-      auto alloc_def=get_object_allocation_def(id, def_map);
-      if(alloc_def!=def_map.end())
-      {
-        if(d_it_b->second.def.kind!=deft::ASSIGNMENT &&
-           to->location_number>alloc_def->second.def.loc->location_number &&
-           to->location_number>d_it_a->second.def.loc->location_number &&
-           to->location_number>d_it_b->second.def.loc->location_number)
-        {
-          def_map[id]=d_it_a->second;
-          def_map[id2string(id).substr(0, id2string(id).find_first_of("."))]=
-            alloc_def->second;
-          result=true;
-          continue;
-        }
-      }
-      alloc_def=get_object_allocation_def(id, b.def_map);
-      if(alloc_def!=b.def_map.end())
-      {
-        if(d_it_a->second.def.kind!=deft::ASSIGNMENT &&
-           to->location_number>alloc_def->second.def.loc->location_number &&
-           to->location_number>d_it_b->second.def.loc->location_number &&
-           to->location_number>d_it_a->second.def.loc->location_number)
-        {
-          def_map[id]=d_it_b->second;
-          def_map[id2string(id).substr(0, id2string(id).find_first_of("."))]=
-            alloc_def->second;
-          result=true;
-          continue;
-        }
-      }
-
       // Arg! Data coming from two sources from two different definitions!
       // We produce a new phi node.
       loc_def_mapt &phi_node=phi_nodes[id];

--- a/src/ssa/ssa_domain.cpp
+++ b/src/ssa/ssa_domain.cpp
@@ -80,8 +80,8 @@ void ssa_domaint::transform(
 {
   if(from->is_assign() || from->is_decl() || from->is_function_call())
   {
-    const std::set<ssa_objectt> &assigns=
-      static_cast<ssa_ait &>(ai).assignments.get(from);
+    const auto &assignments=static_cast<ssa_ait &>(ai).assignments;
+    const std::set<ssa_objectt> &assigns=assignments.get(from);
 
     for(std::set<ssa_objectt>::const_iterator
         o_it=assigns.begin();
@@ -118,8 +118,15 @@ void ssa_domaint::transform(
 
       def_entryt &def_entry=def_map[identifier];
       def_entry.def.loc=from;
-      def_entry.def.kind=deft::ASSIGNMENT;
       def_entry.source=from;
+      auto guard_it=assignments.alloc_guards_map.find({from, *o_it});
+      if(guard_it!=assignments.alloc_guards_map.end())
+      {
+        def_entry.def.kind=deft::ALLOCATION;
+        def_entry.def.guard=guard_it->second;
+      }
+      else
+        def_entry.def.kind=deft::ASSIGNMENT;
     }
   }
   else if(from->is_dead())

--- a/src/ssa/ssa_domain.h
+++ b/src/ssa/ssa_domain.h
@@ -23,6 +23,7 @@ public:
     typedef enum { INPUT, ASSIGNMENT, PHI, ALLOCATION } kindt;
     kindt kind;
     locationt loc;
+    exprt guard=nil_exprt();
 
     inline bool is_input() const { return kind==INPUT; }
     inline bool is_assignment() const { return kind==ASSIGNMENT; }


### PR DESCRIPTION
Currently, we add object allocation guards to the template row post guard to assure that a field of a dynamic object created within a loop can only be updated if it is allocated (i.e. it does not get a non-deterministic value that comes from the input SSA symbol corresponding to the field).
This PR proposes a simpler check for this, we simply add inequality between the SSA version of the field from the end of the loop and the input version to the template row post-guard.
Example: dynamic_object$0.next#10 != dynamic_object$0.next.
Also, this PR fixes a failing Travis checks by fetching the master branch before the linter script is run.