### PR TITLE
Improve checking when a symbolic deref can be reused.

### DIFF
--- a/src/ssa/local_ssa.h
+++ b/src/ssa/local_ssa.h
@@ -229,6 +229,11 @@ public:
     const namespacet &ns,
     const locationt loc);
 
+  bool can_reuse_symderef(
+    ssa_objectt &symderef,
+    const namespacet &ns,
+    const locationt loc);
+
   const ssa_heap_analysist &heap_analysis;
 
   ssa_objectst ssa_objects;

--- a/src/ssa/malloc_ssa.cpp
+++ b/src/ssa/malloc_ssa.cpp
@@ -409,7 +409,7 @@ bool replace_malloc(
                               loop_end==f_it->second.body.instructions.end(),
                               alloc_concrete))
         {
-          result=(loop_end!=f_it->second.body.instructions.end());
+          result=result || (loop_end!=f_it->second.body.instructions.end());
         }
       }
     }


### PR DESCRIPTION
Do not reuse a symbolic dereference in case some aliasing object (or a field of an object) has been assigned after the last definition of the symbolic dereference.
Resolves the problem in #128.
