### PR TITLE
heap-zones: do not add difference rows for dyn objs from the same malloc

### DIFF
--- a/src/domains/tpolyhedra_domain.cpp
+++ b/src/domains/tpolyhedra_domain.cpp
@@ -1032,7 +1032,7 @@ void tpolyhedra_domaint::add_difference_template(
     ++v2;
     for(; v2!=var_specs.end(); ++v2)
     {
-      if (v2->var.id()==ID_and)
+      if(v2->var.id()==ID_and)
         continue;
 
       // Check if both vars are dynamic objects allocated by the same malloc.
@@ -1043,7 +1043,23 @@ void tpolyhedra_domaint::add_difference_template(
         int v1_index=get_dynobj_line(to_symbol_expr(v1->var).get_identifier());
         int v2_index=get_dynobj_line(to_symbol_expr(v2->var).get_identifier());
         if(v1_index>=0 && v2_index>=0 && v1_index==v2_index)
-          continue;
+        {
+          const std::string v1_id=id2string(
+            to_symbol_expr(v1->var).get_identifier());
+          const std::string v2_id=id2string(
+            to_symbol_expr(v2->var).get_identifier());
+          // If the vars are fields of dynamic objects, do not add them if the
+          // fields are the same.
+          if(v1_id.find(".")!=std::string::npos &&
+             v2_id.find(".")!=std::string::npos)
+          {
+            if(v1_id.substr(v1_id.find_first_of("."))==
+               v2_id.substr(v2_id.find_first_of(".")))
+              continue;
+          }
+          else
+            continue;
+        }
       }
 
       kindt k=domaint::merge_kinds(v1->kind, v2->kind);

--- a/src/domains/tpolyhedra_domain.cpp
+++ b/src/domains/tpolyhedra_domain.cpp
@@ -1026,10 +1026,26 @@ void tpolyhedra_domaint::add_difference_template(
   {
     if(v1->var.type().id()==ID_pointer)
       continue;
+    if(v1->var.id()==ID_and)
+      continue;
     var_specst::const_iterator v2=v1;
     ++v2;
     for(; v2!=var_specs.end(); ++v2)
     {
+      if (v2->var.id()==ID_and)
+        continue;
+
+      // Check if both vars are dynamic objects allocated by the same malloc.
+      // In such case, do not add the template row, since only one of those is
+      // always allocated and the combined guard would never hold.
+      if(v1->var.id()==ID_symbol && v2->var.id()==ID_symbol)
+      {
+        int v1_index=get_dynobj_line(to_symbol_expr(v1->var).get_identifier());
+        int v2_index=get_dynobj_line(to_symbol_expr(v2->var).get_identifier());
+        if(v1_index>=0 && v2_index>=0 && v1_index==v2_index)
+          continue;
+      }
+
       kindt k=domaint::merge_kinds(v1->kind, v2->kind);
       if(k==IN)
         continue;

--- a/src/domains/util.cpp
+++ b/src/domains/util.cpp
@@ -710,3 +710,28 @@ bool is_cprover_symbol(const exprt &expr)
            id2string(to_symbol_expr(expr).get_identifier()),
            CPROVER_PREFIX);
 }
+
+/*******************************************************************\
+
+Function: get_dynobj_line
+
+  Inputs: Symbol identifier.
+
+ Outputs: If the symbol is a dynamic object, then the location number of the
+          malloc call where the object was allocated, otherwise -1.
+
+ Purpose:
+
+\*******************************************************************/
+int get_dynobj_line(const irep_idt &id)
+{
+  std::string name=id2string(id);
+  size_t pos=name.find("dynamic_object$");
+  if(pos==std::string::npos)
+    return -1;
+
+  size_t start=pos+15;
+  size_t end=name.find_first_not_of("0123456789", pos);
+  std::string number=name.substr(start, end-start);
+  return std::stoi(number);
+}

--- a/src/domains/util.h
+++ b/src/domains/util.h
@@ -38,4 +38,6 @@ void clean_expr(exprt &expr);
 
 bool is_cprover_symbol(const exprt &expr);
 
+int get_dynobj_line(const irep_idt &id);
+
 #endif


### PR DESCRIPTION
We cannot add a difference template row for two fields of two dynamic objects
allocated at the same allocation site. This is because the combined guard would
never hold since only one of these objects is always allocated.