### PR TITLE
Multiple fixes for SV-COMP

### DIFF
--- a/regression/heap-data/process_queue/test.desc
+++ b/regression/heap-data/process_queue/test.desc
@@ -1,4 +1,4 @@
-CORE
+THOROUGH
 main.c
 --heap-values-refine --sympath --inline
 ^EXIT=0$

--- a/src/2ls/2ls_parse_options.cpp
+++ b/src/2ls/2ls_parse_options.cpp
@@ -1289,6 +1289,9 @@ bool twols_parse_optionst::process_goto_program(
 
     remove_dead_goto(goto_model);
 
+    if(cmdline.isset("competition-mode"))
+      limit_array_bounds(goto_model);
+
     // if we aim to cover, replace
     // all assertions by false to prevent simplification
     if(cmdline.isset("cover-assertions"))

--- a/src/2ls/2ls_parse_options.cpp
+++ b/src/2ls/2ls_parse_options.cpp
@@ -1290,7 +1290,11 @@ bool twols_parse_optionst::process_goto_program(
     remove_dead_goto(goto_model);
 
     if(cmdline.isset("competition-mode"))
+    {
       limit_array_bounds(goto_model);
+      if(options.get_bool_option("memory-leak-check"))
+        memory_assert_info(goto_model);
+    }
 
     // if we aim to cover, replace
     // all assertions by false to prevent simplification

--- a/src/2ls/2ls_parse_options.h
+++ b/src/2ls/2ls_parse_options.h
@@ -204,6 +204,7 @@ protected:
     const std::map<symbol_exprt, size_t> &instance_counts,
     symbol_tablet &symbol_table);
   std::map<symbol_exprt, size_t> split_dynamic_objects(goto_modelt &goto_model);
+  void limit_array_bounds(goto_modelt &goto_model);
 };
 
 #endif

--- a/src/2ls/2ls_parse_options.h
+++ b/src/2ls/2ls_parse_options.h
@@ -205,6 +205,7 @@ protected:
     symbol_tablet &symbol_table);
   std::map<symbol_exprt, size_t> split_dynamic_objects(goto_modelt &goto_model);
   void limit_array_bounds(goto_modelt &goto_model);
+  void memory_assert_info(goto_modelt &goto_model);
 };
 
 #endif

--- a/src/2ls/preprocessing_util.cpp
+++ b/src/2ls/preprocessing_util.cpp
@@ -926,12 +926,13 @@ void twols_parse_optionst::memory_assert_info(goto_modelt &goto_model)
             if(i_it->is_assert())
             {
                 const auto& guard=i_it->guard;
-                if (guard.id() == ID_equal)
+                if(guard.id()==ID_equal)
                 {
-                    if(guard.op0().id()== ID_symbol)
+                    if(guard.op0().id()==ID_symbol)
                     {
-                        const auto& id=id2string(to_symbol_expr(guard.op0()).get_identifier());
-                        if(id.find("__CPROVER_memory_leak") != std::string::npos)
+                        const auto& id=id2string(
+                          to_symbol_expr(guard.op0()).get_identifier());
+                        if(id.find("__CPROVER_memory_leak")!=std::string::npos)
                         {
                             if(!file.empty())
                               i_it->source_location.set_file(file);

--- a/src/2ls/preprocessing_util.cpp
+++ b/src/2ls/preprocessing_util.cpp
@@ -893,3 +893,54 @@ void twols_parse_optionst::limit_array_bounds(goto_modelt &goto_model)
     }
   }
 }
+
+/*******************************************************************\
+
+ Function: twols_parse_optionst::memory_assert_info
+
+ Inputs:
+
+ Outputs:
+
+ Purpose:
+
+ \*******************************************************************/
+void twols_parse_optionst::memory_assert_info(goto_modelt &goto_model)
+{
+    irep_idt file;
+    irep_idt line;
+
+    Forall_goto_functions(f_it, goto_model.goto_functions)
+    {
+        Forall_goto_program_instructions(i_it, f_it->second.body)
+        {
+            if(!i_it->source_location.get_file().empty())
+            {
+                file=i_it->source_location.get_file();
+            }
+            if(!i_it->source_location.get_line().empty())
+            {
+                line=i_it->source_location.get_line();
+            }
+
+            if(i_it->is_assert())
+            {
+                const auto& guard=i_it->guard;
+                if (guard.id() == ID_equal)
+                {
+                    if(guard.op0().id()== ID_symbol)
+                    {
+                        const auto& id=id2string(to_symbol_expr(guard.op0()).get_identifier());
+                        if(id.find("__CPROVER_memory_leak") != std::string::npos)
+                        {
+                            if(!file.empty())
+                              i_it->source_location.set_file(file);
+                            if(!line.empty())
+                              i_it->source_location.set_line(line);
+                        }
+                    }
+                }
+            }
+         }
+      }
+}

--- a/src/2ls/preprocessing_util.cpp
+++ b/src/2ls/preprocessing_util.cpp
@@ -869,3 +869,27 @@ std::map<symbol_exprt, size_t> twols_parse_optionst::split_dynamic_objects(
   }
   return dynobj_instances;
 }
+
+void twols_parse_optionst::limit_array_bounds(goto_modelt &goto_model)
+{
+  Forall_goto_functions(f_it, goto_model.goto_functions)
+  {
+    Forall_goto_program_instructions(i_it, f_it->second.body)
+    {
+      if(i_it->is_decl())
+      {
+        const exprt &symbol=to_code_decl(i_it->code).symbol();
+        if(symbol.type().id()==ID_array)
+        {
+          auto &size_expr=to_array_type(symbol.type()).size();
+          if(size_expr.id()==ID_constant)
+          {
+            int size=std::stoi(
+              id2string(to_constant_expr(size_expr).get_value()), nullptr, 2);
+            assert(size<=50000);
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/2ls/version.h
+++ b/src/2ls/version.h
@@ -9,6 +9,6 @@ Author: Peter Schrammel
 #ifndef CPROVER_2LS_2LS_VERSION_H
 #define CPROVER_2LS_2LS_VERSION_H
 
-#define TWOLS_VERSION "0.7.1"
+#define TWOLS_VERSION "0.7.2"
 
 #endif

--- a/src/domains/tpolyhedra_domain.cpp
+++ b/src/domains/tpolyhedra_domain.cpp
@@ -1044,20 +1044,11 @@ void tpolyhedra_domaint::add_difference_template(
         int v2_index=get_dynobj_line(to_symbol_expr(v2->var).get_identifier());
         if(v1_index>=0 && v2_index>=0 && v1_index==v2_index)
         {
-          const std::string v1_id=id2string(
+          int v1_inst=get_dynobj_instance(
             to_symbol_expr(v1->var).get_identifier());
-          const std::string v2_id=id2string(
+          int v2_inst=get_dynobj_instance(
             to_symbol_expr(v2->var).get_identifier());
-          // If the vars are fields of dynamic objects, do not add them if the
-          // fields are the same.
-          if(v1_id.find(".")!=std::string::npos &&
-             v2_id.find(".")!=std::string::npos)
-          {
-            if(v1_id.substr(v1_id.find_first_of("."))==
-               v2_id.substr(v2_id.find_first_of(".")))
-              continue;
-          }
-          else
+          if(v1_inst>=0 && v2_inst>=0 && v1_inst!=v2_inst)
             continue;
         }
       }

--- a/src/domains/util.cpp
+++ b/src/domains/util.cpp
@@ -735,3 +735,18 @@ int get_dynobj_line(const irep_idt &id)
   std::string number=name.substr(start, end-start);
   return std::stoi(number);
 }
+
+int get_dynobj_instance(const irep_idt &id)
+{
+  std::string name=id2string(id);
+  size_t pos=name.find("dynamic_object$");
+  if(pos==std::string::npos)
+    return -1;
+  pos=name.find_first_of("#", pos);
+  if(pos==std::string::npos)
+    return -1;
+  size_t start=pos+1;
+  size_t end=name.find_first_not_of("0123456789", pos);
+  std::string number=name.substr(start, end-start);
+  return std::stoi(number);
+}

--- a/src/domains/util.h
+++ b/src/domains/util.h
@@ -39,5 +39,6 @@ void clean_expr(exprt &expr);
 bool is_cprover_symbol(const exprt &expr);
 
 int get_dynobj_line(const irep_idt &id);
+int get_dynobj_instance(const irep_idt &id);
 
 #endif


### PR DESCRIPTION
Difference rows for different instances of the same dynamic object (same allocation site) are forbidden, since two such objects cannot exist simultaneously in a single iteration.