### PR TITLE
Improvements for SV-COMP 2020

### DIFF
--- a/src/2ls/2ls_parse_options.cpp
+++ b/src/2ls/2ls_parse_options.cpp
@@ -1127,6 +1127,7 @@ bool twols_parse_optionst::process_goto_program(
     if(options.get_bool_option("pointer-check"))
     {
       allow_record_malloc(goto_model);
+      handle_freed_ptr_compare(goto_model);
     }
     if(options.get_bool_option("memory-leak-check"))
       allow_record_memleak(goto_model);

--- a/src/2ls/2ls_parse_options.cpp
+++ b/src/2ls/2ls_parse_options.cpp
@@ -1060,6 +1060,9 @@ bool twols_parse_optionst::process_goto_program(
 #endif
     }
 
+    if(options.get_bool_option("competition-mode"))
+      assert_no_builtin_functions(goto_model);
+
 #if REMOVE_MULTIPLE_DEREFERENCES
     remove_multiple_dereferences(goto_model);
 #endif

--- a/src/2ls/2ls_parse_options.cpp
+++ b/src/2ls/2ls_parse_options.cpp
@@ -393,6 +393,7 @@ int twols_parse_optionst::doit()
     irep_idt function=cmdline.get_value("function");
     show_ssa(
       goto_model,
+      options,
       heap_analysis,
       function,
       simplify,
@@ -404,14 +405,15 @@ int twols_parse_optionst::doit()
   if(cmdline.isset("show-defs"))
   {
     irep_idt function=cmdline.get_value("function");
-    show_defs(goto_model, function, std::cout, ui_message_handler);
+    show_defs(goto_model, function, options, std::cout, ui_message_handler);
     return 7;
   }
 
   if(cmdline.isset("show-assignments"))
   {
     irep_idt function=cmdline.get_value("function");
-    show_assignments(goto_model, function, std::cout, ui_message_handler);
+    show_assignments(
+      goto_model, function, options, std::cout, ui_message_handler);
     return 7;
   }
 
@@ -425,7 +427,8 @@ int twols_parse_optionst::doit()
   if(cmdline.isset("show-value-sets"))
   {
     irep_idt function=cmdline.get_value("function");
-    show_value_sets(goto_model, function, std::cout, ui_message_handler);
+    show_value_sets(
+      goto_model, function, options, std::cout, ui_message_handler);
     return 7;
   }
 
@@ -574,7 +577,7 @@ int twols_parse_optionst::doit()
 
       if(out_file=="-")
       {
-        horn_encoding(goto_model, std::cout);
+        horn_encoding(goto_model, options, std::cout);
       }
       else
       {
@@ -591,7 +594,7 @@ int twols_parse_optionst::doit()
           return 1;
         }
 
-        horn_encoding(goto_model, out);
+        horn_encoding(goto_model, options, out);
       }
 
       return 0;
@@ -1146,7 +1149,7 @@ bool twols_parse_optionst::process_goto_program(
       inline_main(goto_model);
     }
 
-    auto dynobj_instances=split_dynamic_objects(goto_model);
+    auto dynobj_instances=split_dynamic_objects(goto_model, options);
 
     if(!cmdline.isset("independent-properties"))
     {

--- a/src/2ls/2ls_parse_options.h
+++ b/src/2ls/2ls_parse_options.h
@@ -210,6 +210,7 @@ protected:
   void limit_array_bounds(goto_modelt &goto_model);
   void memory_assert_info(goto_modelt &goto_model);
   void handle_freed_ptr_compare(goto_modelt &goto_model);
+  void assert_no_builtin_functions(goto_modelt &goto_model);
 };
 
 #endif

--- a/src/2ls/2ls_parse_options.h
+++ b/src/2ls/2ls_parse_options.h
@@ -206,7 +206,9 @@ protected:
     goto_programt &goto_program,
     const std::map<symbol_exprt, size_t> &instance_counts,
     symbol_tablet &symbol_table);
-  std::map<symbol_exprt, size_t> split_dynamic_objects(goto_modelt &goto_model);
+  std::map<symbol_exprt, size_t> split_dynamic_objects(
+    goto_modelt &goto_model,
+    const optionst &options);
   void limit_array_bounds(goto_modelt &goto_model);
   void memory_assert_info(goto_modelt &goto_model);
   void handle_freed_ptr_compare(goto_modelt &goto_model);

--- a/src/2ls/2ls_parse_options.h
+++ b/src/2ls/2ls_parse_options.h
@@ -209,6 +209,7 @@ protected:
   std::map<symbol_exprt, size_t> split_dynamic_objects(goto_modelt &goto_model);
   void limit_array_bounds(goto_modelt &goto_model);
   void memory_assert_info(goto_modelt &goto_model);
+  void handle_freed_ptr_compare(goto_modelt &goto_model);
 };
 
 #endif

--- a/src/2ls/horn_encoding.cpp
+++ b/src/2ls/horn_encoding.cpp
@@ -22,9 +22,11 @@ class horn_encodingt
 public:
   horn_encodingt(
     const goto_modelt &_goto_model,
+    const optionst &_options,
     std::ostream &_out):
     goto_functions(_goto_model.goto_functions),
     ns(_goto_model.symbol_table),
+    options(_options),
     out(_out),
     smt2_conv(ns, "", "Horn-clause encoding", "", smt2_convt::Z3, _out)
   {
@@ -35,6 +37,7 @@ public:
 protected:
   const goto_functionst &goto_functions;
   const namespacet ns;
+  const optionst &options;
   std::ostream &out;
 
   smt2_convt smt2_conv;
@@ -61,7 +64,7 @@ void horn_encodingt::translate(
 
   // compute SSA
   ssa_heap_analysist heap_analysis(ns);
-  local_SSAt local_SSA(f_it->second, ns, heap_analysis, "");
+  local_SSAt local_SSA(f_it->second, ns, options, heap_analysis, "");
 
   const goto_programt &body=f_it->second.body;
 
@@ -209,7 +212,8 @@ void horn_encodingt::translate(
 
 void horn_encoding(
   const goto_modelt &goto_model,
+  const optionst &options,
   std::ostream &out)
 {
-  horn_encodingt(goto_model, out)();
+  horn_encodingt(goto_model, options, out)();
 }

--- a/src/2ls/horn_encoding.h
+++ b/src/2ls/horn_encoding.h
@@ -18,6 +18,7 @@ Author:
 
 void horn_encoding(
   const goto_modelt &,
+  const optionst &options,
   std::ostream &out);
 
 #endif

--- a/src/2ls/preprocessing_util.cpp
+++ b/src/2ls/preprocessing_util.cpp
@@ -611,7 +611,7 @@ void twols_parse_optionst::create_dynobj_instances(
 
         const std::string name=id2string(obj_symbol.name);
         const std::string base_name=id2string(obj_symbol.base_name);
-        std::string suffix="#"+std::to_string(0);
+        std::string suffix="$"+std::to_string(0);
 
         obj_symbol.name=name+suffix;
         obj_symbol.base_name=base_name+suffix;
@@ -632,7 +632,7 @@ void twols_parse_optionst::create_dynobj_instances(
           nondet.pretty_name=nondet.name;
           symbol_table.add(nondet);
 
-          suffix="#"+std::to_string(i);
+          suffix="$"+std::to_string(i);
           obj_symbol.name=name+suffix;
           obj_symbol.base_name=base_name+suffix;
 

--- a/src/2ls/preprocessing_util.cpp
+++ b/src/2ls/preprocessing_util.cpp
@@ -653,7 +653,8 @@ void twols_parse_optionst::create_dynobj_instances(
 }
 
 std::map<symbol_exprt, size_t> twols_parse_optionst::split_dynamic_objects(
-  goto_modelt &goto_model)
+  goto_modelt &goto_model,
+  const optionst &options)
 {
   std::map<symbol_exprt, size_t> dynobj_instances;
   Forall_goto_functions(f_it, goto_model.goto_functions)
@@ -661,8 +662,10 @@ std::map<symbol_exprt, size_t> twols_parse_optionst::split_dynamic_objects(
     if(!f_it->second.body_available())
       continue;
     namespacet ns(goto_model.symbol_table);
-    ssa_value_ait value_analysis(f_it->second, ns, ssa_heap_analysist(ns));
-    dynobj_instance_analysist do_inst(f_it->second, ns, value_analysis);
+    ssa_value_ait value_analysis(
+      f_it->second, ns, options, ssa_heap_analysist(ns));
+    dynobj_instance_analysist do_inst(
+      f_it->second, ns, options, value_analysis);
 
     compute_dynobj_instances(
       f_it->second.body, do_inst, dynobj_instances, ns);

--- a/src/2ls/preprocessing_util.cpp
+++ b/src/2ls/preprocessing_util.cpp
@@ -827,3 +827,23 @@ void twols_parse_optionst::handle_freed_ptr_compare(goto_modelt &goto_model)
     }
   }
 }
+
+/// Add assertions preventing analysis of programs using GCC builtin functions
+/// that are not supported and can cause false results.
+void twols_parse_optionst::assert_no_builtin_functions(goto_modelt &goto_model)
+{
+  forall_goto_program_instructions(
+    i_it,
+    goto_model.goto_functions.function_map.find("_start")->second.body)
+  {
+    std::string name=id2string(i_it->source_location.get_function());
+    assert(
+      name.find("__builtin_")==std::string::npos &&
+      name.find("__CPROVER_overflow")==std::string::npos);
+
+    if(i_it->is_assign())
+    {
+      assert(i_it->code.op1().id()!=ID_popcount);
+    }
+  }
+}

--- a/src/2ls/show.cpp
+++ b/src/2ls/show.cpp
@@ -32,14 +32,16 @@ Author: Daniel Kroening, kroening@kroening.com
 void show_assignments(
   const goto_functionst::goto_functiont &goto_function,
   const namespacet &ns,
+  const optionst &options,
   std::ostream &out,
   const ssa_heap_analysist &heap_analysis)
 {
   ssa_objectst ssa_objects(goto_function, ns, heap_analysis);
-  ssa_value_ait ssa_value_ai(goto_function, ns, heap_analysis);
+  ssa_value_ait ssa_value_ai(goto_function, ns, options, heap_analysis);
   assignmentst assignments(
     goto_function.body,
     ns,
+    options,
     ssa_objects,
     ssa_value_ai,
     heap_analysis);
@@ -49,6 +51,7 @@ void show_assignments(
 void show_assignments(
   const goto_modelt &goto_model,
   const irep_idt &function,
+  const optionst &options,
   std::ostream &out,
   message_handlert &message_handler)
 {
@@ -63,7 +66,7 @@ void show_assignments(
     if(f_it==goto_model.goto_functions.function_map.end())
       out << "function " << function << " not found\n";
     else
-      show_assignments(f_it->second, ns, out, heap_analysis);
+      show_assignments(f_it->second, ns, options, out, heap_analysis);
   }
   else
   {
@@ -71,7 +74,7 @@ void show_assignments(
     {
       out << ">>>> Function " << f_it->first << "\n";
 
-      show_assignments(f_it->second, ns, out, heap_analysis);
+      show_assignments(f_it->second, ns, options, out, heap_analysis);
 
       out << "\n";
     }
@@ -81,14 +84,16 @@ void show_assignments(
 void show_defs(
   const goto_functionst::goto_functiont &goto_function,
   const namespacet &ns,
+  const optionst &options,
   std::ostream &out,
   const ssa_heap_analysist &heap_analysis)
 {
   ssa_objectst ssa_objects(goto_function, ns, heap_analysis);
-  ssa_value_ait ssa_value_ai(goto_function, ns, heap_analysis);
+  ssa_value_ait ssa_value_ai(goto_function, ns, options, heap_analysis);
   assignmentst assignments(
     goto_function.body,
     ns,
+    options,
     ssa_objects,
     ssa_value_ai,
     heap_analysis);
@@ -100,6 +105,7 @@ void show_defs(
 void show_defs(
   const goto_modelt &goto_model,
   const irep_idt &function,
+  const optionst &options,
   std::ostream &out,
   message_handlert &message_handler)
 {
@@ -114,7 +120,7 @@ void show_defs(
     if(f_it==goto_model.goto_functions.function_map.end())
       out << "function " << function << " not found\n";
     else
-      show_defs(f_it->second, ns, out, heap_analysis);
+      show_defs(f_it->second, ns, options, out, heap_analysis);
   }
   else
   {
@@ -122,7 +128,7 @@ void show_defs(
     {
       out << ">>>> Function " << f_it->first << "\n";
 
-      show_defs(f_it->second, ns, out, heap_analysis);
+      show_defs(f_it->second, ns, options, out, heap_analysis);
 
       out << "\n";
     }
@@ -173,12 +179,13 @@ void show_ssa(
   const ssa_heap_analysist &heap_analysis,
   bool simplify,
   const namespacet &ns,
+  const optionst &options,
   std::ostream &out)
 {
   if(!goto_function.body_available())
     return;
 
-  unwindable_local_SSAt local_SSA(goto_function, ns, heap_analysis);
+  unwindable_local_SSAt local_SSA(goto_function, ns, options, heap_analysis);
   if(simplify)
     ::simplify(local_SSA, ns);
   local_SSA.output_verbose(out);
@@ -186,6 +193,7 @@ void show_ssa(
 
 void show_ssa(
   const goto_modelt &goto_model,
+  const optionst &options,
   const ssa_heap_analysist &heap_analysis,
   const irep_idt &function,
   bool simplify,
@@ -202,7 +210,7 @@ void show_ssa(
     if(f_it==goto_model.goto_functions.function_map.end())
       out << "function " << function << " not found\n";
     else
-      show_ssa(f_it->second, heap_analysis, simplify, ns, out);
+      show_ssa(f_it->second, heap_analysis, simplify, ns, options, out);
   }
   else
   {
@@ -215,7 +223,7 @@ void show_ssa(
 
       out << ">>>> Function " << f_it->first << "\n";
 
-      show_ssa(f_it->second, heap_analysis, simplify, ns, out);
+      show_ssa(f_it->second, heap_analysis, simplify, ns, options, out);
 
       out << "\n";
     }
@@ -390,17 +398,19 @@ void show_ssa_symbols(
 void show_value_set(
   const goto_functionst::goto_functiont &goto_function,
   const namespacet &ns,
+  const optionst &options,
   std::ostream &out,
   const ssa_heap_analysist &heap_analysis)
 {
   ssa_objectst ssa_objects(goto_function, ns, heap_analysis);
-  ssa_value_ait ssa_value_ai(goto_function, ns, heap_analysis);
+  ssa_value_ait ssa_value_ai(goto_function, ns, options, heap_analysis);
   ssa_value_ai.output(ns, goto_function, out);
 }
 
 void show_value_sets(
   const goto_modelt &goto_model,
   const irep_idt &function,
+  const optionst &options,
   std::ostream &out,
   message_handlert &message_handler)
 {
@@ -415,7 +425,7 @@ void show_value_sets(
     if(f_it==goto_model.goto_functions.function_map.end())
       out << "function " << function << " not found\n";
     else
-      show_value_set(f_it->second, ns, out, heap_analysis);
+      show_value_set(f_it->second, ns, options, out, heap_analysis);
   }
   else
   {
@@ -423,7 +433,7 @@ void show_value_sets(
     {
       out << ">>>> Function " << f_it->first << "\n";
 
-      show_value_set(f_it->second, ns, out, heap_analysis);
+      show_value_set(f_it->second, ns, options, out, heap_analysis);
 
       out << "\n";
     }

--- a/src/2ls/show.h
+++ b/src/2ls/show.h
@@ -26,6 +26,7 @@ class ssa_heap_analysist;
 
 void show_ssa(
   const goto_modelt &,
+  const optionst &,
   const ssa_heap_analysist &,
   const irep_idt &function,
   bool simplify,
@@ -35,18 +36,21 @@ void show_ssa(
 void show_defs(
   const goto_modelt &,
   const irep_idt &function,
+  const optionst &options,
   std::ostream &,
   message_handlert &);
 
 void show_value_sets(
   const goto_modelt &,
   const irep_idt &function,
+  const optionst &options,
   std::ostream &,
   message_handlert &);
 
 void show_assignments(
   const goto_modelt &,
   const irep_idt &function,
+  const optionst &options,
   std::ostream &,
   message_handlert &);
 

--- a/src/2ls/version.h
+++ b/src/2ls/version.h
@@ -12,6 +12,6 @@ Author: Peter Schrammel
 #ifndef CPROVER_2LS_2LS_VERSION_H
 #define CPROVER_2LS_2LS_VERSION_H
 
-#define TWOLS_VERSION "0.8.0"
+#define TWOLS_VERSION "0.8.1"
 
 #endif

--- a/src/2ls/version.h
+++ b/src/2ls/version.h
@@ -12,6 +12,6 @@ Author: Peter Schrammel
 #ifndef CPROVER_2LS_2LS_VERSION_H
 #define CPROVER_2LS_2LS_VERSION_H
 
-#define TWOLS_VERSION "0.8.1"
+#define TWOLS_VERSION "0.8.2"
 
 #endif

--- a/src/domains/template_generator_base.cpp
+++ b/src/domains/template_generator_base.cpp
@@ -134,14 +134,17 @@ void template_generator_baset::collect_variables_loop(
 
         exprt obj_post_guard=post_guard;
 
-        if(id.find("__CPROVER_deallocated")!=std::string::npos)
+        if(!options.get_bool_option("competition-mode"))
         {
-          auto record_frees=collect_record_frees(SSA, n_it->loophead, n_it);
-          exprt::operandst d;
-          for(auto &r : record_frees)
-            d.push_back(equal_exprt(r, true_exprt()));
-          if(!d.empty())
-            obj_post_guard=and_exprt(obj_post_guard, disjunction(d));
+          if(id.find("__CPROVER_deallocated")!=std::string::npos)
+          {
+            auto record_frees=collect_record_frees(SSA, n_it->loophead, n_it);
+            exprt::operandst d;
+            for(auto &r : record_frees)
+              d.push_back(equal_exprt(r, true_exprt()));
+            if(!d.empty())
+              obj_post_guard=and_exprt(obj_post_guard, disjunction(d));
+          }
         }
 
         symbol_exprt pre_var;

--- a/src/domains/tpolyhedra_domain.cpp
+++ b/src/domains/tpolyhedra_domain.cpp
@@ -705,11 +705,11 @@ void tpolyhedra_domaint::add_difference_template(
         int v2_index=get_dynobj_line(to_symbol_expr(v2->var).get_identifier());
         if(v1_index>=0 && v2_index>=0 && v1_index==v2_index)
         {
-          int v1_inst=get_dynobj_instance(
+          std::string v1_inst=get_dynobj_instance(
             to_symbol_expr(v1->var).get_identifier());
-          int v2_inst=get_dynobj_instance(
+          std::string v2_inst=get_dynobj_instance(
             to_symbol_expr(v2->var).get_identifier());
-          if(v1_inst>=0 && v2_inst>=0 && v1_inst!=v2_inst)
+          if(v1_inst!="" && v2_inst!="" && v1_inst!=v2_inst)
             continue;
         }
       }

--- a/src/domains/util.cpp
+++ b/src/domains/util.cpp
@@ -561,22 +561,21 @@ int get_dynobj_line(const irep_idt &id)
     return -1;
 
   size_t start=pos+15;
-  size_t end=name.find_first_not_of("0123456789", pos);
+  size_t end=name.find_first_not_of("0123456789", start);
   std::string number=name.substr(start, end-start);
   return std::stoi(number);
 }
 
-int get_dynobj_instance(const irep_idt &id)
+std::string get_dynobj_instance(const irep_idt &id)
 {
   std::string name=id2string(id);
   size_t pos=name.find("dynamic_object$");
   if(pos==std::string::npos)
-    return -1;
-  pos=name.find('$', pos);
+    return "";
+  pos=name.find('$', pos+15);
   if(pos==std::string::npos)
-    return -1;
+    return "";
   size_t start=pos+1;
-  size_t end=name.find_first_not_of("0123456789", pos);
-  std::string number=name.substr(start, end-start);
-  return std::stoi(number);
+  size_t end=name.find_first_not_of("0123456789co", start);
+  return name.substr(start, end-start);
 }

--- a/src/domains/util.cpp
+++ b/src/domains/util.cpp
@@ -572,7 +572,7 @@ int get_dynobj_instance(const irep_idt &id)
   size_t pos=name.find("dynamic_object$");
   if(pos==std::string::npos)
     return -1;
-  pos=name.find_first_of("#", pos);
+  pos=name.find('$', pos);
   if(pos==std::string::npos)
     return -1;
   size_t start=pos+1;

--- a/src/domains/util.h
+++ b/src/domains/util.h
@@ -42,6 +42,6 @@ void clean_expr(exprt &expr);
 bool is_cprover_symbol(const exprt &expr);
 
 int get_dynobj_line(const irep_idt &id);
-int get_dynobj_instance(const irep_idt &id);
+std::string get_dynobj_instance(const irep_idt &id);
 
 #endif

--- a/src/ssa/assignments.cpp
+++ b/src/ssa/assignments.cpp
@@ -29,7 +29,9 @@ void assignmentst::build_assignment_map(
     if(it->is_assign())
     {
       const code_assignt &code_assign=to_code_assign(it->code);
-      exprt lhs_deref=dereference(code_assign.lhs(), ssa_value_ai[it], "", ns);
+      exprt lhs_deref=dereference(
+        code_assign.lhs(), ssa_value_ai[it], "", ns,
+        options.get_bool_option("competition-mode"));
       assign(lhs_deref, it, ns);
       exprt lhs_symbolic_deref=symbolic_dereference(code_assign.lhs(), ns);
       assign(lhs_symbolic_deref, it, ns);
@@ -94,7 +96,9 @@ void assignmentst::build_assignment_map(
 
         if(arg!=modified)
         {
-          const exprt arg_deref=dereference(arg, ssa_value_ai[it], "", ns);
+          bool comp=options.get_bool_option("competition-mode");
+          const exprt arg_deref=dereference(
+            arg, ssa_value_ai[it], "", ns, comp);
           assign(arg_deref, it, ns);
 
           std::set<symbol_exprt> symbols;
@@ -117,7 +121,9 @@ void assignmentst::build_assignment_map(
       if(code_function_call.lhs().is_not_nil())
       {
         exprt lhs_deref=
-          dereference(code_function_call.lhs(), ssa_value_ai[it], "", ns);
+          dereference(
+            code_function_call.lhs(), ssa_value_ai[it], "", ns,
+            options.get_bool_option("competition-mode"));
         assign(lhs_deref, it, ns);
       }
     }

--- a/src/ssa/assignments.h
+++ b/src/ssa/assignments.h
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_2LS_SSA_ASSIGNMENTS_H
 
 #include <goto-programs/goto_functions.h>
+#include <util/options.h>
 
 #include "ssa_object.h"
 #include "ssa_value_set.h"
@@ -52,12 +53,14 @@ public:
   assignmentst(
     const goto_programt &_goto_program,
     const namespacet &_ns,
+    const optionst &_options,
     const ssa_objectst &_ssa_objects,
     const ssa_value_ait &_ssa_value_ai,
     const ssa_heap_analysist &_ssa_heap_analysis):
     ssa_objects(_ssa_objects),
     ssa_value_ai(_ssa_value_ai),
-    ssa_heap_analysis(_ssa_heap_analysis)
+    ssa_heap_analysis(_ssa_heap_analysis),
+    options(_options)
   {
     build_assignment_map(_goto_program, _ns);
   }
@@ -90,6 +93,8 @@ protected:
     const exprt &guard,
     const locationt loc,
     const namespacet &ns);
+
+  const optionst &options;
 };
 
 #endif

--- a/src/ssa/dynobj_instance_analysis.cpp
+++ b/src/ssa/dynobj_instance_analysis.cpp
@@ -97,7 +97,11 @@ void dynobj_instance_domaint::rhs_concretisation(
           // 1) now make dereference
           const auto &values=
             static_cast<dynobj_instance_analysist &>(ai).value_analysis[loc];
-          const auto guard_deref=dereference(guard, values, "", ns);
+          bool competition_mode=
+            static_cast<dynobj_instance_analysist &>(ai).options
+              .get_bool_option("competition-mode");
+          const auto guard_deref=dereference(
+            guard, values, "", ns, competition_mode);
           auto value_set=values(guard_deref, ns).value_set;
           // 2) then isolate for all values in value set of dereferences
           for(auto &v : value_set)
@@ -120,6 +124,9 @@ void dynobj_instance_domaint::transform(
   ai_baset &ai,
   const namespacet &ns)
 {
+  bool competition_mode=
+    static_cast<dynobj_instance_analysist &>(ai).options
+      .get_bool_option("competition-mode");
   if(from->is_assign())
   {
     const code_assignt &assignment=to_code_assign(from->code);
@@ -137,7 +144,8 @@ void dynobj_instance_domaint::transform(
       // For allocation site, the assigned pointer has no aliases
       const auto &values=
         static_cast<dynobj_instance_analysist &>(ai).value_analysis[to];
-      const auto lhs_deref=dereference(assignment.lhs(), values, "", ns);
+      const auto lhs_deref=dereference(
+        assignment.lhs(), values, "", ns, competition_mode);
       auto value_set=values(lhs_deref, ns).value_set;
       for(auto &v : value_set)
         must_alias_relations[v.symbol_expr()].isolate(lhs);
@@ -152,7 +160,7 @@ void dynobj_instance_domaint::transform(
 
       const auto &values=
         static_cast<dynobj_instance_analysist &>(ai).value_analysis[from];
-      const auto rhs_deref=dereference(rhs, values, "", ns);
+      const auto rhs_deref=dereference(rhs, values, "", ns, competition_mode);
       auto value_set=values(rhs_deref, ns).value_set;
       for(auto &v : value_set)
       {

--- a/src/ssa/dynobj_instance_analysis.h
+++ b/src/ssa/dynobj_instance_analysis.h
@@ -24,6 +24,7 @@ Description: In some cases, multiple instances must be used so that the
 
 #include <analyses/ai.h>
 #include <util/union_find.h>
+#include <util/options.h>
 #include "ssa_object.h"
 #include "ssa_value_set.h"
 
@@ -172,13 +173,16 @@ public:
   dynobj_instance_analysist(
     const goto_functionst::goto_functiont &goto_function,
     const namespacet &ns,
+    const optionst &_options,
     ssa_value_ait &_value_ai):
+    options(_options),
     value_analysis(_value_ai)
   {
     operator()(goto_function, ns);
   }
 
 protected:
+  const optionst &options;
   ssa_value_ait &value_analysis;
 
   friend class dynobj_instance_domaint;

--- a/src/ssa/local_ssa.cpp
+++ b/src/ssa/local_ssa.cpp
@@ -309,7 +309,9 @@ exprt local_SSAt::dereference(const exprt &src, locationt loc) const
 {
   const ssa_value_domaint &ssa_value_domain=ssa_value_ai[loc];
   const std::string nondet_prefix="deref#"+i2string(loc->location_number);
-  return ::dereference(src, ssa_value_domain, nondet_prefix, ns);
+  return ::dereference(
+    src, ssa_value_domain, nondet_prefix, ns,
+    options.get_bool_option("competition-mode"));
 }
 
 void local_SSAt::build_transfer(locationt loc)

--- a/src/ssa/local_ssa.h
+++ b/src/ssa/local_ssa.h
@@ -18,6 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <domains/list_iterator.h>
 #include <domains/incremental_solver.h>
+#include <util/options.h>
 
 #include "ssa_domain.h"
 #include "guard_map.h"
@@ -39,14 +40,20 @@ public:
   inline local_SSAt(
     const goto_functiont &_goto_function,
     const namespacet &_ns,
+    const optionst &_options,
     const ssa_heap_analysist &_heap_analysis,
     const std::string &_suffix=""):
-    ns(_ns), goto_function(_goto_function),
+    ns(_ns), goto_function(_goto_function), options(_options),
     heap_analysis(_heap_analysis),
     ssa_objects(_goto_function, ns, _heap_analysis),
-    ssa_value_ai(_goto_function, ns, _heap_analysis),
+    ssa_value_ai(_goto_function, ns, options, _heap_analysis),
     assignments(
-      _goto_function.body, ns, ssa_objects, ssa_value_ai, heap_analysis),
+      _goto_function.body,
+      ns,
+      options,
+      ssa_objects,
+      ssa_value_ai,
+      heap_analysis),
     alias_analysis(_goto_function, ns),
     guard_map(_goto_function.body),
     ssa_analysis(assignments),
@@ -166,6 +173,7 @@ public:
 
   const namespacet &ns;
   const goto_functiont &goto_function;
+  const optionst &options;
 
   // guards
   ssa_objectt cond_symbol() const;

--- a/src/ssa/ssa_db.h
+++ b/src/ssa/ssa_db.h
@@ -71,7 +71,7 @@ public:
     const ssa_heap_analysist &heap_analysis)
   {
     store[function_name]=
-      new unwindable_local_SSAt(goto_function, ns, heap_analysis);
+      new unwindable_local_SSAt(goto_function, ns, options, heap_analysis);
   }
 
 protected:

--- a/src/ssa/ssa_dereference.cpp
+++ b/src/ssa/ssa_dereference.cpp
@@ -248,6 +248,9 @@ exprt ssa_alias_value(
   }
 
   byte_extract_exprt byte_extract(byte_extract_id(), e1.type());
+#ifdef COMPETITION
+  assert(!e2_type.get_bool("#dynamic"));
+#endif
   byte_extract.op()=e2;
   byte_extract.offset()=offset1;
 

--- a/src/ssa/ssa_dereference.cpp
+++ b/src/ssa/ssa_dereference.cpp
@@ -215,7 +215,8 @@ exprt ssa_alias_guard(
 exprt ssa_alias_value(
   const exprt &e1,
   const exprt &e2,
-  const namespacet &ns)
+  const namespacet &ns,
+  bool competition_mode)
 {
   const typet &e1_type=ns.follow(e1.type());
   const typet &e2_type=ns.follow(e2.type());
@@ -248,9 +249,8 @@ exprt ssa_alias_value(
   }
 
   byte_extract_exprt byte_extract(byte_extract_id(), e1.type());
-#ifdef COMPETITION
-  assert(!e2_type.get_bool("#dynamic"));
-#endif
+  if(competition_mode)
+    assert(!e2_type.get_bool("#dynamic"));
   byte_extract.op()=e2;
   byte_extract.offset()=offset1;
 
@@ -261,7 +261,8 @@ exprt dereference_rec(
   const exprt &src,
   const ssa_value_domaint &ssa_value_domain,
   const std::string &nondet_prefix,
-  const namespacet &ns)
+  const namespacet &ns,
+  bool competition_mode)
 {
   if(src.id()==ID_dereference)
   {
@@ -269,7 +270,8 @@ exprt dereference_rec(
       to_dereference_expr(src).pointer(),
       ssa_value_domain,
       nondet_prefix,
-      ns);
+      ns,
+      competition_mode);
 
     const typet &pointed_type=ns.follow(pointer.type().subtype());
 
@@ -297,14 +299,14 @@ exprt dereference_rec(
       }
       else
       {
-        result=ssa_alias_value(src, (it++)->get_expr(), ns);
+        result=ssa_alias_value(src, (it++)->get_expr(), ns, competition_mode);
         result.set("#heap_access", result.type().get_bool("#dynamic"));
       }
 
       for(; it!=values.value_set.end(); ++it)
       {
         exprt guard=ssa_alias_guard(src, it->get_expr(), ns);
-        exprt value=ssa_alias_value(src, it->get_expr(), ns);
+        exprt value=ssa_alias_value(src, it->get_expr(), ns, competition_mode);
         result=if_exprt(guard, value, result);
         result.set(
           "#heap_access",
@@ -318,8 +320,8 @@ exprt dereference_rec(
   else if(src.id()==ID_member)
   {
     member_exprt tmp=to_member_expr(src);
-    tmp.struct_op()=
-      dereference_rec(tmp.struct_op(), ssa_value_domain, nondet_prefix, ns);
+    tmp.struct_op()=dereference_rec(
+      tmp.struct_op(), ssa_value_domain, nondet_prefix, ns, competition_mode);
     tmp.set("#heap_access", tmp.struct_op().get_bool("#heap_access"));
 
     #ifdef DEBUG
@@ -334,8 +336,8 @@ exprt dereference_rec(
   else if(src.id()==ID_address_of)
   {
     address_of_exprt tmp=to_address_of_expr(src);
-    tmp.object()=
-      dereference_rec(tmp.object(), ssa_value_domain, nondet_prefix, ns);
+    tmp.object()=dereference_rec(
+      tmp.object(), ssa_value_domain, nondet_prefix, ns, competition_mode);
     tmp.set("#heap_access", tmp.object().get_bool("#heap_access"));
 
     if(tmp.object().is_nil())
@@ -348,7 +350,8 @@ exprt dereference_rec(
     exprt tmp=src;
     Forall_operands(it, tmp)
     {
-      *it=dereference_rec(*it, ssa_value_domain, nondet_prefix, ns);
+      *it=dereference_rec(
+        *it, ssa_value_domain, nondet_prefix, ns, competition_mode);
       if(it->get_bool("#heap_access"))
         tmp.set("#heap_access", true);
     }
@@ -360,13 +363,15 @@ exprt dereference(
   const exprt &src,
   const ssa_value_domaint &ssa_value_domain,
   const std::string &nondet_prefix,
-  const namespacet &ns)
+  const namespacet &ns,
+  bool competition_mode)
 {
   #ifdef DEBUG
   std::cout << "dereference src: " << from_expr(ns, "", src) << '\n';
   #endif
 
-  exprt tmp1=dereference_rec(src, ssa_value_domain, nondet_prefix, ns);
+  exprt tmp1=dereference_rec(
+    src, ssa_value_domain, nondet_prefix, ns, competition_mode);
 
   #ifdef DEBUG
   std::cout << "dereference tmp1: " << from_expr(ns, "", tmp1) << '\n';

--- a/src/ssa/ssa_dereference.h
+++ b/src/ssa/ssa_dereference.h
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/std_expr.h>
 #include <util/namespace.h>
+#include <util/options.h>
 
 #include "ssa_value_set.h"
 
@@ -21,6 +22,7 @@ exprt dereference(
   const exprt &,
   const ssa_value_domaint &,
   const std::string &nondet_prefix,
-  const namespacet &);
+  const namespacet &,
+  bool competition_mode);
 
 #endif

--- a/src/ssa/ssa_value_set.h
+++ b/src/ssa/ssa_value_set.h
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_2LS_SSA_SSA_VALUE_SET_H
 
 #include <analyses/ai.h>
+#include <util/options.h>
 
 #include "ssa_object.h"
 #include "ssa_heap_domain.h"
@@ -66,7 +67,11 @@ public:
   typedef std::map<ssa_objectt, valuest> value_mapt;
   value_mapt value_map;
 
-  const valuest operator()(const exprt &src, const namespacet &ns) const
+  bool competition_mode;
+
+  const valuest operator()(
+    const exprt &src,
+    const namespacet &ns) const
   {
     valuest tmp;
     assign_rhs_rec(tmp, src, ns, false, 0);
@@ -115,8 +120,10 @@ public:
   ssa_value_ait(
     const goto_functionst::goto_functiont &goto_function,
     const namespacet &ns_,
+    const optionst &_options,
     const ssa_heap_analysist &_heap_analysis):
     ns(ns_),
+    options(_options),
     heap_analysis(_heap_analysis)
   {
     operator()(goto_function, ns_);
@@ -131,6 +138,7 @@ protected:
   void assign(const exprt &src, const exprt &dest, ssa_value_domaint &entry);
 
   const namespacet &ns;
+  const optionst &options;
 
   const ssa_heap_analysist &heap_analysis;
 

--- a/src/ssa/unwindable_local_ssa.h
+++ b/src/ssa/unwindable_local_ssa.h
@@ -23,9 +23,10 @@ public:
   unwindable_local_SSAt(
     const goto_functiont &_goto_function,
     const namespacet &_ns,
+    const optionst &_options,
     const ssa_heap_analysist &heap_analysis,
     const std::string &_suffix=""):
-    local_SSAt(_goto_function, _ns, heap_analysis, _suffix),
+    local_SSAt(_goto_function, _ns, _options, heap_analysis, _suffix),
     current_unwinding(-1)
   {
     compute_loop_hierarchy();


### PR DESCRIPTION
There are multiple things implemented:
- handle comparison of freed pointers
- fix bugs in work with dynamic objects

With these changes, we have no false results in heap-related categories (except for 2 long-known false positives).