### PR TITLE
Handle comparison of freed pointers in assertions

### DIFF
--- a/src/2ls/preprocessing_util.cpp
+++ b/src/2ls/preprocessing_util.cpp
@@ -804,7 +804,7 @@ void twols_parse_optionst::handle_freed_ptr_compare(goto_modelt &goto_model)
   {
     Forall_goto_program_instructions(i_it, f_it->second.body)
     {
-      if(i_it->is_goto())
+      if(i_it->is_goto() || i_it->is_assert())
       {
         auto &guard=i_it->guard;
         make_freed_ptr_comparison_nondet(


### PR DESCRIPTION
Until now, we only handled correct comparison of freed pointers in normal conditions, not in assertions.