### PR TITLE
Store domain and its value in summary

### DIFF
--- a/src/2ls/graphml_witness_ext.cpp
+++ b/src/2ls/graphml_witness_ext.cpp
@@ -19,16 +19,22 @@ void graphml_witness_extt::operator()(
   const unwindable_local_SSAt &ssa=
     static_cast<const unwindable_local_SSAt &>(
       summary_checker.ssa_db.get(function_name));
-  summaryt summary;
-  if(summary_checker.summary_db.exists(function_name))
-    summary=summary_checker.summary_db.get(function_name);
   const ssa_local_unwindert &ssa_unwinder=
   summary_checker.ssa_unwinder.get(function_name);
 
   graphml.key_values["sourcecodelang"]="C";
 
   dynamic_cfgt cfg;
-  cfg(ssa_unwinder, ssa, summary);
+  if(summary_checker.summary_db.exists(function_name))
+  {
+    const summaryt &summary=summary_checker.summary_db.get(function_name);
+    cfg(ssa_unwinder, ssa, summary);
+  }
+  else
+  {
+    cfg(ssa_unwinder, ssa, summaryt());
+  }
+
 
   // CFG to CFA
   const graphmlt::node_indext sink=graphml.add_node();

--- a/src/2ls/instrument_goto.cpp
+++ b/src/2ls/instrument_goto.cpp
@@ -126,7 +126,7 @@ void instrument_gotot::instrument_function(
   if(!summary_db.exists(function_name))
     return;
 
-  const summaryt summary=summary_db.get(function_name);
+  const summaryt &summary=summary_db.get(function_name);
 
   if(!ssa_db.exists(function_name))
     return;

--- a/src/domains/ssa_analyzer.h
+++ b/src/domains/ssa_analyzer.h
@@ -36,6 +36,10 @@ public:
 
   inline unsigned get_number_of_solver_instances() { return solver_instances; }
   inline unsigned get_number_of_solver_calls() { return solver_calls; }
+  std::unique_ptr<domaint::valuet> get_abstract_value()
+  {
+    return std::move(result);
+  }
 
 protected:
   domaint *domain; // template generator is responsible for the domain object

--- a/src/domains/template_generator_base.h
+++ b/src/domains/template_generator_base.h
@@ -54,6 +54,11 @@ public:
     return domain_ptr.get();
   }
 
+  std::unique_ptr<domaint> get_domain()
+  {
+    return std::move(domain_ptr);
+  };
+
   var_specst var_specs;
   replace_mapt post_renaming_map;
   replace_mapt init_renaming_map;

--- a/src/solver/summarizer_base.cpp
+++ b/src/solver/summarizer_base.cpp
@@ -230,7 +230,7 @@ bool summarizer_baset::check_precondition(
 
   if(summary_db.exists(fname))
   {
-    summaryt summary=summary_db.get(fname);
+    const summaryt &summary=summary_db.get(fname);
     if(summary.mark_recompute)
       return false;
     if(!context_sensitive ||

--- a/src/solver/summarizer_bw.cpp
+++ b/src/solver/summarizer_bw.cpp
@@ -157,6 +157,8 @@ void summarizer_bwt::do_summary(
       summary.bw_transformer, template_generator.inout_vars());
     analyzer.get_result(summary.bw_invariant, template_generator.loop_vars());
     analyzer.get_result(summary.bw_precondition, template_generator.out_vars());
+    summary.bw_domain_ptr=template_generator.get_domain();
+    summary.bw_value_ptr=analyzer.get_abstract_value();
 
     // statistics
     solver_instances+=analyzer.get_number_of_solver_instances();

--- a/src/solver/summarizer_bw.h
+++ b/src/solver/summarizer_bw.h
@@ -71,14 +71,14 @@ protected:
   virtual void collect_postconditions(
     const function_namet &function_name,
     const local_SSAt &SSA,
-    const summaryt &summary,
+    const exprt &postcondition,
     exprt::operandst &postconditions,
     bool sufficient);
 
   virtual exprt compute_calling_context2(
     const function_namet &function_name,
     local_SSAt &SSA,
-    summaryt old_summary,
+    const summaryt &old_summary,
     local_SSAt::nodest::const_iterator n_it,
     local_SSAt::nodet::function_callst::const_iterator f_it,
     const exprt &postcondition,

--- a/src/solver/summarizer_bw_term.cpp
+++ b/src/solver/summarizer_bw_term.cpp
@@ -84,7 +84,7 @@ void summarizer_bw_termt::compute_summary_rec(
   }
 
   // store summary in db
-  summary_db.put(function_name, summary);
+  summary_db.put(function_name, std::move(summary));
 
   {
     std::ostringstream out;
@@ -145,7 +145,12 @@ void summarizer_bw_termt::do_summary_term(
   exprt::operandst postcond;
   // backward summaries
   ssa_inliner.get_summaries(SSA, false, postcond, bindings);
-  collect_postconditions(function_name, SSA, summary, postcond, true);
+  collect_postconditions(
+    function_name,
+    SSA,
+    summary.bw_postcondition,
+    postcond,
+    true);
 
   // prepare solver
   solver << SSA;

--- a/src/solver/summarizer_bw_term.cpp
+++ b/src/solver/summarizer_bw_term.cpp
@@ -269,7 +269,7 @@ void summarizer_bw_termt::do_summary_term(
       postcond.clear();
     }
   }
-
+  summary.bw_domain_ptr=template_generator2.get_domain();
   solver.pop_context();
 }
 
@@ -369,6 +369,7 @@ exprt summarizer_bw_termt::compute_precondition(
   exprt postcond=not_exprt(conjunction(postconditions));
 
   // compute backward summary
+  summaryt bw_summary;
   exprt bw_transformer, bw_invariant, bw_precondition;
   if(!template_generator.out_vars().empty())
   {
@@ -378,6 +379,7 @@ exprt summarizer_bw_termt::compute_precondition(
     analyzer.get_result(bw_transformer, template_generator.inout_vars());
     analyzer.get_result(bw_invariant, template_generator.loop_vars());
     analyzer.get_result(bw_precondition, template_generator.out_vars());
+    summary.bw_value_ptr=analyzer.get_abstract_value();
 
     // statistics
     solver_instances+=analyzer.get_number_of_solver_instances();
@@ -426,6 +428,7 @@ exprt summarizer_bw_termt::compute_precondition(
     summary.bw_invariant=or_exprt(summary.bw_invariant, bw_invariant);
     summary.bw_precondition=or_exprt(summary.bw_precondition, bw_precondition);
   }
+  summary.bw_value_ptr=std::move(bw_summary.bw_value_ptr);
 
   return bw_precondition;
 }

--- a/src/solver/summarizer_fw.cpp
+++ b/src/solver/summarizer_fw.cpp
@@ -77,7 +77,7 @@ void summarizer_fwt::compute_summary_rec(
 #endif
 
   // store summary in db
-  summary_db.put(function_name, summary);
+  summary_db.put(function_name, std::move(summary));
 
   if(!options.get_bool_option("competition-mode"))
   {

--- a/src/solver/summarizer_fw.cpp
+++ b/src/solver/summarizer_fw.cpp
@@ -138,6 +138,8 @@ void summarizer_fwt::do_summary(
   analyzer(solver, SSA, cond, template_generator);
   analyzer.get_result(summary.fw_transformer, template_generator.inout_vars());
   analyzer.get_result(summary.fw_invariant, template_generator.loop_vars());
+  summary.fw_domain_ptr=template_generator.get_domain();
+  summary.fw_value_ptr=analyzer.get_abstract_value();
 
 #ifdef SHOW_WHOLE_RESULT
   // to see all the custom template values

--- a/src/solver/summarizer_fw_contexts.cpp
+++ b/src/solver/summarizer_fw_contexts.cpp
@@ -132,7 +132,7 @@ void summarizer_fw_contextst::inline_summaries(
         summary.fw_precondition=precondition_call;
         summary.fw_transformer=true_exprt();
 
-        summary_db.put(fname, summary);
+        summary_db.put(fname, std::move(summary));
         continue;
       }
 

--- a/src/solver/summarizer_fw_term.cpp
+++ b/src/solver/summarizer_fw_term.cpp
@@ -271,6 +271,8 @@ void summarizer_fw_termt::do_termination(
   if(!summary.fw_precondition.is_true())
     summary.termination_argument=
       implies_exprt(summary.fw_precondition, summary.termination_argument);
+  summary.fw_domain_ptr=template_generator1.get_domain();
+  summary.fw_value_ptr=analyzer1.get_abstract_value();
 
   // statistics
   solver_instances+=analyzer1.get_number_of_solver_instances();

--- a/src/solver/summarizer_fw_term.cpp
+++ b/src/solver/summarizer_fw_term.cpp
@@ -147,7 +147,7 @@ void summarizer_fw_termt::compute_summary_rec(
   }
 
   // store summary in db
-  summary_db.put(function_name, summary);
+  summary_db.put(function_name, std::move(summary));
 }
 
 void summarizer_fw_termt::inline_summaries(

--- a/src/solver/summary.h
+++ b/src/solver/summary.h
@@ -17,6 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/std_expr.h>
 #include <ssa/local_ssa.h>
+#include <domains/domain.h>
 
 typedef enum {YES, NO, UNKNOWN} threevalt;
 
@@ -52,6 +53,15 @@ class summaryt
   predicatet bw_postcondition; // accumulated postconditions (over/under-approx)
   predicatet bw_transformer; // backward summary (over- or under-approx)
   predicatet bw_invariant; // backward invariant (over- or under-approx)
+
+  // The following fields represent the used abstract domains (containing
+  // the template) and the corresponding computed abstract values.
+  // These can be useful to retrieve information that cannot be easily parsed
+  // from the invariant expression.
+  std::unique_ptr<domaint> fw_domain_ptr; // forward abstract domain
+  std::unique_ptr<domaint::valuet> fw_value_ptr; // forward abstract value
+  std::unique_ptr<domaint> bw_domain_ptr; // backward abstract domain
+  std::unique_ptr<domaint::valuet> bw_value_ptr; // backward abstract value
 
   predicatet aux_precondition;
 

--- a/src/solver/summary_db.cpp
+++ b/src/solver/summary_db.cpp
@@ -17,11 +17,11 @@ Author: Daniel Kroening, kroening@kroening.com
 
 void summary_dbt::put(
   const function_namet &function_name,
-  const summaryt &summary)
+  summaryt &&summary)
 {
   if(store.find(function_name)==store.end() ||
      store[function_name].mark_recompute)
-    store[function_name]=summary;
+    store[function_name]=std::move(summary);
   else
     store[function_name].join(summary);
 }

--- a/src/solver/summary_db.h
+++ b/src/solver/summary_db.h
@@ -26,11 +26,11 @@ public:
   void write();
   void clear() { store.clear(); }
 
-  summaryt get(const function_namet &function_name) const
+  const summaryt &get(const function_namet &function_name) const
     { return store.at(function_name); }
   bool exists(const function_namet &function_name) const
     { return store.find(function_name)!=store.end(); }
-  void put(const function_namet &function_name, const summaryt &summary);
+  void put(const function_namet &function_name, summaryt &&summary);
 
   void mark_recompute_all();
 

--- a/src/ssa/ssa_inliner.cpp
+++ b/src/ssa/ssa_inliner.cpp
@@ -179,7 +179,7 @@ void ssa_inlinert::replace(
 
       if(summary_db.exists(fname))
       {
-        summaryt summary=summary_db.get(fname);
+        const summaryt &summary=summary_db.get(fname);
 
         status() << "Replacing function " << fname << " by summary" << eom;
 


### PR DESCRIPTION
This is a preparation for implementation of GOTO code instrumentation. It will be useful to have access to the whole domain to be able to easily instrument GOTO code with invariants. It was necessary to slightly tweak how summary_db works with summaries (previously, summaries were copied when obtaining them from summary_db, references are returned after the changes).