### PR TITLE
Update to CBMC 5.8

### DIFF
--- a/regression/instrumentation/pointers/main.c
+++ b/regression/instrumentation/pointers/main.c
@@ -1,13 +1,13 @@
-typedef struct data {
+struct data {
     struct data *next;
     int content;
-} Data;
+};
 
 void main() {
-    Data x1 = {0,};
-    Data x2 = {&x1,};
-    Data x3 = {&x2,};
-    Data *curr = &x3;
+    struct data x1 = {0,};
+    struct data x2 = {&x1,};
+    struct data x3 = {&x2,};
+    struct data *curr = &x3;
     while (curr) {
         assert(curr->content == 0);
         curr = curr->next;

--- a/regression/preconditions/precond_contextsensitive2/test.desc
+++ b/regression/preconditions/precond_contextsensitive2/test.desc
@@ -3,4 +3,4 @@ main.c
 --context-sensitive --preconditions
 ^EXIT=5$
 ^SIGNAL=0$
-^\[_start\]: argc' <= 268435456 && -\(\(signed __CPROVER_bitvector\[33\]\)argc'\) <= -2$
+^\[__CPROVER__start\]: argc' <= 268435456 && -\(\(signed __CPROVER_bitvector\[33\]\)argc'\) <= -2$

--- a/regression/termination/precond_term1/test.desc
+++ b/regression/termination/precond_term1/test.desc
@@ -3,4 +3,4 @@ main.c
 --preconditions
 ^EXIT=5$
 ^SIGNAL=0$
-\[_start\]: !\(argc' <= 1 && -\(\(signed __CPROVER_bitvector\[33\]\)argc'\) <= -1\)
+\[__CPROVER__start\]: !\(argc' <= 1 && -\(\(signed __CPROVER_bitvector\[33\]\)argc'\) <= -1\)

--- a/src/2ls/2ls_parse_options.cpp
+++ b/src/2ls/2ls_parse_options.cpp
@@ -633,7 +633,7 @@ int twols_parse_optionst::doit()
     // do actual analysis
     switch((*checker)(goto_model))
     {
-    case property_checkert::PASS:
+    case property_checkert::resultt::PASS:
       if(report_assertions)
         report_properties(options, goto_model, checker->property_map);
       report_success();
@@ -642,7 +642,7 @@ int twols_parse_optionst::doit()
       retval=0;
       break;
 
-    case property_checkert::FAIL:
+    case property_checkert::resultt::FAIL:
     {
       if(report_assertions)
         report_properties(options, goto_model, checker->property_map);
@@ -651,7 +651,7 @@ int twols_parse_optionst::doit()
       bool trace_valid=false;
       for(const auto &p : checker->property_map)
       {
-        if(p.second.result!=property_checkert::FAIL)
+        if(p.second.result!=property_checkert::resultt::FAIL)
           continue;
 
         if(options.get_bool_option("trace"))
@@ -681,7 +681,7 @@ int twols_parse_optionst::doit()
       retval=10;
       break;
     }
-    case property_checkert::UNKNOWN:
+    case property_checkert::resultt::UNKNOWN:
       if(report_assertions)
         report_properties(options, goto_model, checker->property_map);
       retval=5;
@@ -963,7 +963,7 @@ bool twols_parse_optionst::get_goto_program(
 
       language->set_message_handler(get_message_handler());
 
-      status("Parsing", filename);
+      status() << "Parsing" << filename << eom;
 
       if(language->parse(infile, filename))
       {
@@ -1049,6 +1049,7 @@ bool twols_parse_optionst::process_goto_program(
   {
     status() << "Function Pointer Removal" << eom;
     remove_function_pointers(
+      get_message_handler(),
       goto_model,
       cmdline.isset("pointer-check"));
 
@@ -1062,7 +1063,7 @@ bool twols_parse_optionst::process_goto_program(
 
       // remove inlined functions
       Forall_goto_functions(f_it, goto_model.goto_functions)
-        if(f_it->first!=ID__start &&
+        if(f_it->first!=goto_functionst::entry_point() &&
            f_it->second.body.instructions.size()<=2*(limit/2))
         {
           f_it->second.body.clear();
@@ -1285,10 +1286,10 @@ void twols_parse_optionst::report_properties(
 #endif
 
     if(!options.get_bool_option("all-properties") &&
-       it->second.result!=property_checkert::FAIL)
+       it->second.result!=property_checkert::resultt::FAIL)
       continue;
 
-    if(get_ui()==ui_message_handlert::XML_UI)
+    if(get_ui()==ui_message_handlert::uit::XML_UI)
     {
       xmlt xml_result("result");
       xml_result.set_attribute("property", id2string(it->first));
@@ -1307,10 +1308,10 @@ void twols_parse_optionst::report_properties(
     }
 
     if(options.get_bool_option("trace") &&
-       it->second.result==property_checkert::FAIL)
+       it->second.result==property_checkert::resultt::FAIL)
       show_counterexample(goto_model, it->second.error_trace);
     if(cmdline.isset("json-cex") &&
-       it->second.result==property_checkert::FAIL)
+       it->second.result==property_checkert::resultt::FAIL)
       output_json_cex(
         options,
         goto_model,
@@ -1330,9 +1331,9 @@ void twols_parse_optionst::report_properties(
         it!=property_map.end();
         it++)
     {
-      if(it->second.result==property_checkert::UNKNOWN)
+      if(it->second.result==property_checkert::resultt::UNKNOWN)
         unknown++;
-      if(it->second.result==property_checkert::FAIL)
+      if(it->second.result==property_checkert::resultt::FAIL)
         failed++;
     }
 
@@ -1351,10 +1352,10 @@ void twols_parse_optionst::report_success()
 
   switch(get_ui())
   {
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     break;
 
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
   {
     xmlt xml("cprover-status");
     xml.data="SUCCESS";
@@ -1376,12 +1377,12 @@ void twols_parse_optionst::show_counterexample(
 
   switch(get_ui())
   {
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     std::cout << std::endl << "Counterexample:" << std::endl;
     show_goto_trace(std::cout, ns, error_trace);
     break;
 
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
   {
     xmlt xml;
     convert(ns, error_trace, xml);
@@ -1401,7 +1402,7 @@ void twols_parse_optionst::output_graphml_cex(
 {
   for(const auto &p : summary_checker.property_map)
   {
-    if(p.second.result!=property_checkert::FAIL)
+    if(p.second.result!=property_checkert::resultt::FAIL)
       continue;
 
     const namespacet ns(goto_model.symbol_table);
@@ -1475,10 +1476,10 @@ void twols_parse_optionst::report_failure()
 
   switch(get_ui())
   {
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     break;
 
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
   {
     xmlt xml("cprover-status");
     xml.data="FAILURE";
@@ -1498,10 +1499,10 @@ void twols_parse_optionst::report_unknown()
 
   switch(get_ui())
   {
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     break;
 
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
   {
     xmlt xml("cprover-status");
     xml.data="UNKNOWN";

--- a/src/2ls/2ls_parse_options.cpp
+++ b/src/2ls/2ls_parse_options.cpp
@@ -151,10 +151,10 @@ void twols_parse_optionst::get_command_line_options(optionst &options)
   else
     options.set_option("std-invariants", false);
 
-  if(cmdline.isset("no-propagation"))
-    options.set_option("constant-propagation", false);
-  else
+  if(cmdline.isset("constant-propagation"))
     options.set_option("constant-propagation", true);
+  else
+    options.set_option("constant-propagation", false);
 
   // magic error label
   if(cmdline.isset("error-label"))

--- a/src/2ls/2ls_parse_options.h
+++ b/src/2ls/2ls_parse_options.h
@@ -66,6 +66,7 @@ class optionst;
   "(graphml-witness):(json-cex):" \
   "(no-spurious-check)(stop-on-fail)" \
   "(competition-mode)(slice)(no-propagation)(independent-properties)" \
+  "(constant-propagation)" \
   "(no-unwinding-assertions)"
   // the last line is for CBMC-regression testing only
 

--- a/src/2ls/cover_goals_ext.cpp
+++ b/src/2ls/cover_goals_ext.cpp
@@ -84,10 +84,10 @@ void cover_goals_extt::operator()()
 
     switch(dec_result)
     {
-    case decision_proceduret::D_UNSATISFIABLE: // DONE
+    case decision_proceduret::resultt::D_UNSATISFIABLE: // DONE
       break;
 
-    case decision_proceduret::D_SATISFIABLE:
+    case decision_proceduret::resultt::D_SATISFIABLE:
       // mark the goals we got
       mark();
 
@@ -103,7 +103,7 @@ void cover_goals_extt::operator()()
       return;
     }
   }
-  while(dec_result==decision_proceduret::D_SATISFIABLE &&
+  while(dec_result==decision_proceduret::resultt::D_SATISFIABLE &&
         number_covered()<size());
 }
 
@@ -130,10 +130,10 @@ void cover_goals_extt::assignment()
     for(goal_mapt::const_iterator it=goal_map.begin();
         it!=goal_map.end(); it++, g_it++)
     {
-      if(property_map[it->first].result==property_checkert::UNKNOWN &&
+      if(property_map[it->first].result==property_checkert::resultt::UNKNOWN &&
          solver.l_get(g_it->condition).is_true())
       {
-        property_map[it->first].result=property_checkert::FAIL;
+        property_map[it->first].result=property_checkert::resultt::FAIL;
         if(build_error_trace)
         {
           ssa_build_goto_tracet build_goto_trace(SSA, solver.get_solver());
@@ -153,16 +153,16 @@ void cover_goals_extt::assignment()
 
   switch(solver())
   {
-  case decision_proceduret::D_SATISFIABLE:
+  case decision_proceduret::resultt::D_SATISFIABLE:
   {
     std::list<cover_goals_extt::cover_goalt>::const_iterator g_it=goals.begin();
     for(goal_mapt::const_iterator it=goal_map.begin();
         it!=goal_map.end(); it++, g_it++)
     {
-      if(property_map[it->first].result==property_checkert::UNKNOWN &&
+      if(property_map[it->first].result==property_checkert::resultt::UNKNOWN &&
          solver.l_get(g_it->condition).is_true())
       {
-        property_map[it->first].result=property_checkert::FAIL;
+        property_map[it->first].result=property_checkert::resultt::FAIL;
         if(build_error_trace)
         {
           ssa_build_goto_tracet build_goto_trace(SSA, solver.get_solver());
@@ -179,10 +179,10 @@ void cover_goals_extt::assignment()
     }
     break;
   }
-  case decision_proceduret::D_UNSATISFIABLE:
+  case decision_proceduret::resultt::D_UNSATISFIABLE:
     break;
 
-  case decision_proceduret::D_ERROR:
+  case decision_proceduret::resultt::D_ERROR:
   default:
     throw "error from decision procedure";
   }

--- a/src/2ls/graphml_witness_ext.cpp
+++ b/src/2ls/graphml_witness_ext.cpp
@@ -15,7 +15,7 @@ Author: Peter Schrammel
 void graphml_witness_extt::operator()(
   const summary_checker_baset &summary_checker)
 {
-  irep_idt function_name=ID__start;
+  irep_idt function_name=goto_functionst::entry_point();
   const unwindable_local_SSAt &ssa=
     static_cast<const unwindable_local_SSAt &>(
       summary_checker.ssa_db.get(function_name));

--- a/src/2ls/horn_encoding.cpp
+++ b/src/2ls/horn_encoding.cpp
@@ -29,7 +29,7 @@ public:
     ns(_goto_model.symbol_table),
     options(_options),
     out(_out),
-    smt2_conv(ns, "", "Horn-clause encoding", "", smt2_convt::Z3, _out)
+    smt2_conv(ns, "", "Horn-clause encoding", "", smt2_convt::solvert::Z3, _out)
   {
   }
 

--- a/src/2ls/preprocessing_util.cpp
+++ b/src/2ls/preprocessing_util.cpp
@@ -22,7 +22,8 @@ Author: Peter Schrammel
 
 void twols_parse_optionst::inline_main(goto_modelt &goto_model)
 {
-  goto_programt &main=goto_model.goto_functions.function_map[ID__start].body;
+  irep_idt start=goto_functionst::entry_point();
+  goto_programt &main=goto_model.goto_functions.function_map[start].body;
   goto_programt::targett target=main.instructions.begin();
   while(target!=main.instructions.end())
   {
@@ -155,7 +156,7 @@ bool twols_parse_optionst::unwind_goto_into_loop(
         l_it->second,
         l_it->first,
         k,
-        goto_unwindt::PARTIAL, iteration_points);
+        goto_unwindt::unwind_strategyt::PARTIAL, iteration_points);
 
       assert(iteration_points.size()==2);
       goto_programt::targett t=body.insert_before(l_it->first);
@@ -798,7 +799,8 @@ void twols_parse_optionst::assert_no_builtin_functions(goto_modelt &goto_model)
 {
   forall_goto_program_instructions(
     i_it,
-    goto_model.goto_functions.function_map.find("_start")->second.body)
+    goto_model.goto_functions.function_map.find(
+      goto_model.goto_functions.entry_point())->second.body)
   {
     std::string name=id2string(i_it->source_location.get_function());
     assert(

--- a/src/2ls/summary_checker_ai.cpp
+++ b/src/2ls/summary_checker_ai.cpp
@@ -32,7 +32,7 @@ property_checkert::resultt summary_checker_ait::operator()(
   // properties
   initialize_property_map(goto_model.goto_functions);
 
-  property_checkert::resultt result=property_checkert::UNKNOWN;
+  property_checkert::resultt result=property_checkert::resultt::UNKNOWN;
   bool finished=false;
   while(!finished)
   {
@@ -54,7 +54,7 @@ property_checkert::resultt summary_checker_ait::operator()(
     {
       report_statistics();
       report_preconditions();
-      return property_checkert::UNKNOWN;
+      return property_checkert::resultt::UNKNOWN;
     }
 
     if(termination)
@@ -65,13 +65,13 @@ property_checkert::resultt summary_checker_ait::operator()(
 
 #ifdef SHOW_CALLINGCONTEXTS
     if(options.get_bool_option("show-calling-contexts"))
-      return property_checkert::UNKNOWN;
+      return property_checkert::resultt::UNKNOWN;
 #endif
 
     result=check_properties();
     report_statistics();
 
-    if(result==property_checkert::UNKNOWN &&
+    if(result==property_checkert::resultt::UNKNOWN &&
        options.get_bool_option("values-refine") &&
        options.get_bool_option("intervals"))
     {
@@ -134,17 +134,17 @@ property_checkert::resultt summary_checker_ait::report_termination()
        << (!computed ? "not computed" : threeval2string(terminates)) << eom;
   }
   if(not_computed)
-    return property_checkert::UNKNOWN;
+    return property_checkert::resultt::UNKNOWN;
   if(all_terminate)
-    return property_checkert::PASS;
+    return property_checkert::resultt::PASS;
   if(one_nonterminate)
   {
 #if 0
-    return property_checkert::FAIL;
+    return property_checkert::resultt::FAIL;
 #else
     // rely on nontermination checker to find counterexample
-    return property_checkert::UNKNOWN;
+    return property_checkert::resultt::UNKNOWN;
 #endif
   }
-  return property_checkert::UNKNOWN;
+  return property_checkert::resultt::UNKNOWN;
 }

--- a/src/2ls/summary_checker_base.cpp
+++ b/src/2ls/summary_checker_base.cpp
@@ -140,14 +140,14 @@ summary_checker_baset::resultt summary_checker_baset::check_properties()
     }
   }
 
-  summary_checker_baset::resultt result=property_checkert::PASS;
+  summary_checker_baset::resultt result=property_checkert::resultt::PASS;
   for(property_mapt::const_iterator
         p_it=property_map.begin(); p_it!=property_map.end(); p_it++)
   {
-    if(p_it->second.result==FAIL)
-      return property_checkert::FAIL;
-    if(p_it->second.result==UNKNOWN)
-      result=property_checkert::UNKNOWN;
+    if(p_it->second.result==property_checkert::resultt::FAIL)
+      return property_checkert::resultt::FAIL;
+    if(p_it->second.result==property_checkert::resultt::UNKNOWN)
+      result=property_checkert::resultt::UNKNOWN;
   }
 
   return result;
@@ -231,12 +231,12 @@ void summary_checker_baset::check_properties(
 
     if(i_it->guard.is_true())
     {
-      property_map[property_id].result=PASS;
+      property_map[property_id].result=property_checkert::resultt::PASS;
       continue;
     }
 
     // do not recheck properties that have already been decided
-    if(property_map[property_id].result!=UNKNOWN)
+    if(property_map[property_id].result!=property_checkert::resultt::UNKNOWN)
       continue;
 
     // TODO: some properties do not show up in initialize_property_map
@@ -300,7 +300,7 @@ void summary_checker_baset::check_properties(
         it++, g_it++)
     {
       if(!g_it->covered)
-        property_map[it->first].result=PASS;
+        property_map[it->first].result=property_checkert::resultt::PASS;
     }
   }
 
@@ -435,18 +435,18 @@ bool summary_checker_baset::is_fully_unwound(
 
   switch(solver())
   {
-  case decision_proceduret::D_SATISFIABLE:
+  case decision_proceduret::resultt::D_SATISFIABLE:
     solver.pop_context();
     return false;
     break;
 
-  case decision_proceduret::D_UNSATISFIABLE:
+  case decision_proceduret::resultt::D_UNSATISFIABLE:
     solver.pop_context();
     solver << conjunction(loophead_selects);
     return true;
     break;
 
-  case decision_proceduret::D_ERROR:
+  case decision_proceduret::resultt::D_ERROR:
   default:
     throw "error from decision procedure";
   }
@@ -478,15 +478,15 @@ bool summary_checker_baset::is_spurious(
 
   switch(solver())
   {
-  case decision_proceduret::D_SATISFIABLE:
+  case decision_proceduret::resultt::D_SATISFIABLE:
     return false;
     break;
 
-  case decision_proceduret::D_UNSATISFIABLE:
+  case decision_proceduret::resultt::D_UNSATISFIABLE:
     return true;
     break;
 
-  case decision_proceduret::D_ERROR:
+  case decision_proceduret::resultt::D_ERROR:
   default:
     throw "error from decision procedure";
   }

--- a/src/2ls/summary_checker_base.h
+++ b/src/2ls/summary_checker_base.h
@@ -42,10 +42,7 @@ public:
     solver_instances(0),
     solver_calls(0),
     summaries_used(0),
-    termargs_computed(0)
-  {
-    ssa_inliner.set_message_handler(get_message_handler());
-  }
+    termargs_computed(0) {}
 
   bool show_vcc, simplify, fixed_point;
   irep_idt function_to_check;
@@ -53,6 +50,12 @@ public:
   virtual resultt operator()(const goto_modelt &) { assert(false); }
 
   void instrument_and_output(goto_modelt &goto_model, unsigned verbosity);
+
+  void set_message_handler(message_handlert &_message_handler) override
+  {
+    messaget::set_message_handler(_message_handler);
+    ssa_inliner.set_message_handler(_message_handler);
+  }
 
   // statistics
   absolute_timet start_time;

--- a/src/2ls/summary_checker_bmc.cpp
+++ b/src/2ls/summary_checker_bmc.cpp
@@ -19,7 +19,7 @@ property_checkert::resultt summary_checker_bmct::operator()(
 
   ssa_unwinder.init(false, true);
 
-  property_checkert::resultt result=property_checkert::UNKNOWN;
+  property_checkert::resultt result=property_checkert::resultt::UNKNOWN;
   unsigned max_unwind=options.get_unsigned_int_option("unwind");
   status() << "Max-unwind is " << max_unwind << eom;
   ssa_unwinder.init_localunwinders();
@@ -30,13 +30,13 @@ property_checkert::resultt summary_checker_bmct::operator()(
     summary_db.mark_recompute_all();
     ssa_unwinder.unwind_all(unwind);
     result=check_properties();
-    if(result==property_checkert::PASS)
+    if(result==property_checkert::resultt::PASS)
     {
       status() << "incremental BMC proof found after "
          << unwind << " unwinding(s)" << messaget::eom;
       break;
     }
-    else if(result==property_checkert::FAIL)
+    else if(result==property_checkert::resultt::FAIL)
     {
       status() << "incremental BMC counterexample found after "
          << unwind << " unwinding(s)" << messaget::eom;

--- a/src/2ls/summary_checker_kind.cpp
+++ b/src/2ls/summary_checker_kind.cpp
@@ -18,7 +18,7 @@ property_checkert::resultt summary_checker_kindt::operator()(
 
   ssa_unwinder.init(true, false);
 
-  property_checkert::resultt result=property_checkert::UNKNOWN;
+  property_checkert::resultt result=property_checkert::resultt::UNKNOWN;
   unsigned max_unwind=options.get_unsigned_int_option("unwind");
   unsigned give_up_invariants=
     options.get_unsigned_int_option("give-up-invariants");
@@ -38,7 +38,7 @@ property_checkert::resultt summary_checker_kindt::operator()(
     bool magic_limit_not_reached=
       unwind<give_up_invariants ||
       !options.get_bool_option("competition-mode");
-    if(result==property_checkert::UNKNOWN &&
+    if(result==property_checkert::resultt::UNKNOWN &&
        !options.get_bool_option("havoc") &&
        magic_limit_not_reached)
     {
@@ -46,13 +46,13 @@ property_checkert::resultt summary_checker_kindt::operator()(
       result=check_properties();
     }
 
-    if(result==property_checkert::PASS)
+    if(result==property_checkert::resultt::PASS)
     {
       status() << "k-induction proof found after "
          << unwind << " unwinding(s)" << eom;
       break;
     }
-    else if(result==property_checkert::FAIL)
+    else if(result==property_checkert::resultt::FAIL)
     {
       status() << "k-induction counterexample found after "
          << unwind << " unwinding(s)" << eom;

--- a/src/2ls/summary_checker_nonterm.cpp
+++ b/src/2ls/summary_checker_nonterm.cpp
@@ -26,7 +26,7 @@ property_checkert::resultt summary_checker_nontermt::operator()(
 
   ssa_unwinder.init(false, true);
 
-  property_checkert::resultt result=property_checkert::UNKNOWN;
+  property_checkert::resultt result=property_checkert::resultt::UNKNOWN;
   unsigned max_unwind=options.get_unsigned_int_option("unwind");
   status() << "Max-unwind is " << max_unwind << eom;
   ssa_unwinder.init_localunwinders();
@@ -38,14 +38,14 @@ property_checkert::resultt summary_checker_nontermt::operator()(
     if(unwind==51)  // use a different nontermination technique
     {
       result=check_nonterm_linear();
-      if(result==property_checkert::PASS)
+      if(result==property_checkert::resultt::PASS)
       {
         status() << "Termination proved after "
            << unwind << " unwinding(s)" << messaget::eom;
         report_statistics();
         return result;
       }
-      else if(result==property_checkert::FAIL)
+      else if(result==property_checkert::resultt::FAIL)
       {
         status() << "Nonterminating program execution proved after "
            << unwind << " unwinding(s)" << messaget::eom;
@@ -54,13 +54,13 @@ property_checkert::resultt summary_checker_nontermt::operator()(
       }
     }
     result=summary_checker_baset::check_properties();
-    if(result==property_checkert::PASS)
+    if(result==property_checkert::resultt::PASS)
     {
       status() << "Termination proved after "
          << unwind << " unwinding(s)" << messaget::eom;
       break;
     }
-    else if(result==property_checkert::FAIL)
+    else if(result==property_checkert::resultt::FAIL)
     {
       status() << "Nonterminating program execution proved after "
          << unwind << " unwinding(s)" << messaget::eom;
@@ -170,7 +170,7 @@ void summary_checker_nontermt::check_properties(
       SSA.current_unwinding=store_unwinding;
 
       property_map[property_id].location=n_it->loophead->location;
-      property_map[property_id].result=UNKNOWN;
+      property_map[property_id].result=property_checkert::resultt::UNKNOWN;
       cover_goals.goal_map[property_id].conjuncts.push_back(
         disjunction(loop_check_operands));
       ls_guards.push_back(not_exprt(lsguard));
@@ -274,7 +274,7 @@ void summary_checker_nontermt::check_properties_linear(
       exprt::operandst neg_loop_exit_cond;
 
       property_map[property_id].location=n_it->loophead->location;
-      property_map[property_id].result=UNKNOWN;
+      property_map[property_id].result=property_checkert::resultt::UNKNOWN;
 
       unsigned const_number=0;
       for(local_SSAt::objectst::const_iterator
@@ -363,11 +363,11 @@ void summary_checker_nontermt::check_properties_linear(
       solver << conjunction(first_linearity_check);
       switch(solver())
       {
-      case decision_proceduret::D_UNSATISFIABLE:
+      case decision_proceduret::resultt::D_UNSATISFIABLE:
           solver.pop_context();
         continue;
 
-      case decision_proceduret::D_SATISFIABLE:
+      case decision_proceduret::resultt::D_SATISFIABLE:
           for(exprt::operandst::iterator it=first_linearity_check.begin();
               it!=first_linearity_check.end();
               ++it)
@@ -393,11 +393,11 @@ void summary_checker_nontermt::check_properties_linear(
       solver << disjunction(second_linearity_check);
       switch(solver())
       {
-      case decision_proceduret::D_UNSATISFIABLE:
+      case decision_proceduret::resultt::D_UNSATISFIABLE:
           solver.pop_context();
         break;
 
-      case decision_proceduret::D_SATISFIABLE:
+      case decision_proceduret::resultt::D_SATISFIABLE:
           solver.pop_context();
         continue;
 
@@ -415,12 +415,12 @@ void summary_checker_nontermt::check_properties_linear(
       solver << conjunction(constants_computation);
       switch(solver())
       {
-      case decision_proceduret::D_UNSATISFIABLE: // should never happen
+      case decision_proceduret::resultt::D_UNSATISFIABLE: // should never happen
           solver.pop_context();
           solver.pop_context();
         return;
 
-      case decision_proceduret::D_SATISFIABLE:
+      case decision_proceduret::resultt::D_SATISFIABLE:
           for(auto constant : constants)
           {
             exprt ex=solver.solver->get(constant);
@@ -485,10 +485,10 @@ void summary_checker_nontermt::check_properties_linear(
         exprt::operandst local_constraints;
         switch(result=solver())
         {
-        case decision_proceduret::D_UNSATISFIABLE:
+        case decision_proceduret::resultt::D_UNSATISFIABLE:
           break;
 
-        case decision_proceduret::D_SATISFIABLE:
+        case decision_proceduret::resultt::D_SATISFIABLE:
             lbv_it=loopback_vars.begin();
             slvc_it=solver_consts.begin();
             while(slvc_it!=solver_consts.end())
@@ -530,7 +530,7 @@ void summary_checker_nontermt::check_properties_linear(
           return;
         }
       }
-      while(result!=decision_proceduret::D_UNSATISFIABLE);
+      while(result!=decision_proceduret::resultt::D_UNSATISFIABLE);
 
       solver.pop_context();
 
@@ -539,13 +539,13 @@ void summary_checker_nontermt::check_properties_linear(
 
       switch(solver())
       {
-      case decision_proceduret::D_UNSATISFIABLE:
+      case decision_proceduret::resultt::D_UNSATISFIABLE:
           solver.pop_context();
         break;
 
-      case decision_proceduret::D_SATISFIABLE:
+      case decision_proceduret::resultt::D_SATISFIABLE:
         // found nontermination
-          property_map[property_id].result=FAIL;
+          property_map[property_id].result=property_checkert::resultt::FAIL;
           solver.pop_context();
           solver.pop_context();
         return;
@@ -572,14 +572,14 @@ summary_checker_baset::resultt summary_checker_nontermt::check_nonterm_linear()
     check_properties_linear(f_it);
   }
 
-  summary_checker_baset::resultt result=property_checkert::PASS;
+  summary_checker_baset::resultt result=property_checkert::resultt::PASS;
   for(property_mapt::const_iterator
         p_it=property_map.begin(); p_it!=property_map.end(); p_it++)
   {
-    if(p_it->second.result==FAIL)
-      return property_checkert::FAIL;
-    if(p_it->second.result==UNKNOWN)
-      result=property_checkert::UNKNOWN;
+    if(p_it->second.result==property_checkert::resultt::FAIL)
+      return property_checkert::resultt::FAIL;
+    if(p_it->second.result==property_checkert::resultt::UNKNOWN)
+      result=property_checkert::resultt::UNKNOWN;
   }
 
   return result;

--- a/src/2ls/version.h
+++ b/src/2ls/version.h
@@ -12,6 +12,6 @@ Author: Peter Schrammel
 #ifndef CPROVER_2LS_2LS_VERSION_H
 #define CPROVER_2LS_2LS_VERSION_H
 
-#define TWOLS_VERSION "0.9.2"
+#define TWOLS_VERSION "0.9.3"
 
 #endif

--- a/src/domains/heap_domain.cpp
+++ b/src/domains/heap_domain.cpp
@@ -98,7 +98,7 @@ exprt heap_domaint::value_to_ptr_exprt(const exprt &expr)
   {
     const std::string value=id2string(to_constant_expr(expr).get_value());
     if(value.substr(value.size()/2).find_first_not_of('0')!=std::string::npos)
-      return plus_exprt(expr.op0(), constant_exprt::integer_constant(0));
+      return plus_exprt(expr.op0(), make_zero(integer_typet()));
     else
       return expr.op0();
   }

--- a/src/domains/lexlinrank_domain.cpp
+++ b/src/domains/lexlinrank_domain.cpp
@@ -82,8 +82,8 @@ bool lexlinrank_domaint::edit_row(const rowt &row, valuet &inv, bool improved)
   }
 
   // solve
-  bool inner_solver_result=(*inner_solver)();
-  if(inner_solver_result==decision_proceduret::D_SATISFIABLE &&
+  decision_proceduret::resultt inner_solver_result=(*inner_solver)();
+  if(inner_solver_result==decision_proceduret::resultt::D_SATISFIABLE &&
      number_inner_iterations<max_inner_iterations)
   {
     number_inner_iterations++;

--- a/src/domains/linrank_domain.cpp
+++ b/src/domains/linrank_domain.cpp
@@ -66,7 +66,7 @@ bool linrank_domaint::edit_row(const rowt &row, valuet &inv, bool improved)
   }
 
   // solve
-  if((*inner_solver)()==decision_proceduret::D_SATISFIABLE &&
+  if((*inner_solver)()==decision_proceduret::resultt::D_SATISFIABLE &&
      number_inner_iterations<max_inner_iterations)
   {
     std::vector<exprt> c=symb_values.c;

--- a/src/domains/strategy_solver_binsearch.cpp
+++ b/src/domains/strategy_solver_binsearch.cpp
@@ -64,7 +64,7 @@ bool strategy_solver_binsearcht::iterate(invariantt &_inv)
   debug() << "solve(): ";
 #endif
 
-  if(solver()==decision_proceduret::D_SATISFIABLE) // improvement check
+  if(solver()==decision_proceduret::resultt::D_SATISFIABLE) // improvement check
   {
 #if 0
     debug() << "SAT" << eom;
@@ -168,7 +168,7 @@ bool strategy_solver_binsearcht::iterate(invariantt &_inv)
 
       solver << c;
 
-      if(solver()==decision_proceduret::D_SATISFIABLE)
+      if(solver()==decision_proceduret::resultt::D_SATISFIABLE)
       {
 #if 0
         debug() << "SAT" << eom;

--- a/src/domains/strategy_solver_binsearch2.cpp
+++ b/src/domains/strategy_solver_binsearch2.cpp
@@ -74,7 +74,8 @@ bool strategy_solver_binsearch2t::iterate(invariantt &_inv)
 
   std::set<tpolyhedra_domaint::rowt> improve_rows;
   bool improved_from_neginf=false;
-  while(solver()==decision_proceduret::D_SATISFIABLE) // improvement check
+  // improvement check
+  while(solver()==decision_proceduret::resultt::D_SATISFIABLE)
   {
 #if 0
     debug() << "SAT" << eom;
@@ -194,7 +195,7 @@ bool strategy_solver_binsearch2t::iterate(invariantt &_inv)
 
     solver << c;
 
-    if(solver()==decision_proceduret::D_SATISFIABLE)
+    if(solver()==decision_proceduret::resultt::D_SATISFIABLE)
     {
 #if 0
       debug() << "SAT" << eom;

--- a/src/domains/strategy_solver_binsearch3.cpp
+++ b/src/domains/strategy_solver_binsearch3.cpp
@@ -69,7 +69,8 @@ bool strategy_solver_binsearch3t::iterate(invariantt &_inv)
   std::map<tpolyhedra_domaint::rowt, constant_exprt> lower_values;
   exprt::operandst blocking_constraint;
   bool improved_from_neginf=false;
-  while(solver()==decision_proceduret::D_SATISFIABLE) // improvement check
+  // improvement check
+  while(solver()==decision_proceduret::resultt::D_SATISFIABLE)
   {
 #if 0
     debug() << "SAT" << eom;
@@ -195,7 +196,7 @@ bool strategy_solver_binsearch3t::iterate(invariantt &_inv)
 
     solver << c;
 
-    if(solver()==decision_proceduret::D_SATISFIABLE)
+    if(solver()==decision_proceduret::resultt::D_SATISFIABLE)
     {
 #if 0
       debug() << "SAT" << eom;

--- a/src/domains/strategy_solver_simple.cpp
+++ b/src/domains/strategy_solver_simple.cpp
@@ -44,7 +44,7 @@ bool strategy_solver_simplet::iterate(invariantt &_inv)
     adjust_float_expressions(cond, SSA.ns);
     solver << cond;
 
-    if(solver()==decision_proceduret::D_SATISFIABLE)
+    if(solver()==decision_proceduret::resultt::D_SATISFIABLE)
     {
 #ifdef DEBUG
       std::cerr << "Pre-condition:\n";

--- a/src/domains/strategy_solver_sympath.cpp
+++ b/src/domains/strategy_solver_sympath.cpp
@@ -132,7 +132,7 @@ bool strategy_solver_sympatht::is_current_path_feasible(
 
     // If loop is not reachable in the current context of computed summary,
     // the path is infeasible
-    if(solver()==decision_proceduret::D_UNSATISFIABLE)
+    if(solver()==decision_proceduret::resultt::D_UNSATISFIABLE)
       result=false;
 
     solver.pop_context();

--- a/src/domains/template_generator_summary.cpp
+++ b/src/domains/template_generator_summary.cpp
@@ -36,7 +36,8 @@ void template_generator_summaryt::operator()(
   collect_variables_loop(SSA, forward);
 
   // do not compute summary for entry-point
-  if(SSA.goto_function.body.instructions.front().function!=ID__start ||
+  if(SSA.goto_function.body.instructions.front().function!=
+     goto_functionst::entry_point() ||
      options.get_bool_option("preconditions"))
     collect_variables_inout(SSA, forward);
 

--- a/src/domains/util.cpp
+++ b/src/domains/util.cpp
@@ -467,6 +467,8 @@ constant_exprt make_zero(const typet &type)
     cst.make_zero();
     return cst.to_expr();
   }
+  if(type.id()==ID_integer)
+    return constant_exprt("0", type);
   assert(false);
 }
 

--- a/src/solver/summarizer_base.cpp
+++ b/src/solver/summarizer_base.cpp
@@ -110,13 +110,13 @@ bool summarizer_baset::check_call_reachable(
 
   switch(solver())
   {
-  case decision_proceduret::D_SATISFIABLE:
+  case decision_proceduret::resultt::D_SATISFIABLE:
   {
     reachable=true;
     debug() << "Call is reachable" << eom;
     break;
   }
-  case decision_proceduret::D_UNSATISFIABLE:
+  case decision_proceduret::resultt::D_UNSATISFIABLE:
   {
     debug() << "Call is not reachable" << eom;
     break;
@@ -297,14 +297,14 @@ bool summarizer_baset::check_precondition(
 
   switch(solver())
   {
-  case decision_proceduret::D_SATISFIABLE:
+  case decision_proceduret::resultt::D_SATISFIABLE:
   {
     precondition_holds=false;
 
     status() << "Precondition does not hold, need to recompute summary." << eom;
     break;
   }
-  case decision_proceduret::D_UNSATISFIABLE:
+  case decision_proceduret::resultt::D_UNSATISFIABLE:
   {
     precondition_holds=true;
 
@@ -346,7 +346,7 @@ bool summarizer_baset::check_end_reachable(
 
   solver << not_exprt(conjunction(assertions)); // we want to reach any of them
 
-  bool result=(solver()==decision_proceduret::D_SATISFIABLE);
+  bool result=(solver()==decision_proceduret::resultt::D_SATISFIABLE);
 
   solver.pop_context();
 

--- a/src/solver/summarizer_bw.cpp
+++ b/src/solver/summarizer_bw.cpp
@@ -174,7 +174,7 @@ void summarizer_bwt::do_summary(
     solver << SSA.get_enabling_exprs();
     solver << conjunction(c);
     exprt result=true_exprt();
-    if(solver()==decision_proceduret::D_UNSATISFIABLE)
+    if(solver()==decision_proceduret::resultt::D_UNSATISFIABLE)
       result=false_exprt();
     solver.pop_context();
     summary.bw_transformer=result;
@@ -348,14 +348,14 @@ bool summarizer_bwt::check_postcondition(
 
   switch(solver())
   {
-  case decision_proceduret::D_SATISFIABLE:
+  case decision_proceduret::resultt::D_SATISFIABLE:
   {
     precondition_holds=false;
 
     status() << "Precondition does not hold, need to recompute summary." << eom;
     break;
   }
-  case decision_proceduret::D_UNSATISFIABLE:
+  case decision_proceduret::resultt::D_UNSATISFIABLE:
   {
     precondition_holds=true;
 

--- a/src/solver/summarizer_bw_term.cpp
+++ b/src/solver/summarizer_bw_term.cpp
@@ -300,7 +300,7 @@ bool summarizer_bw_termt::bootstrap_preconditions(
 
     // solve
     exprt precondition;
-    if(solver()==decision_proceduret::D_SATISFIABLE)
+    if(solver()==decision_proceduret::resultt::D_SATISFIABLE)
     {
       exprt::operandst c;
       for(var_sett::const_iterator it=invars.begin();
@@ -395,7 +395,7 @@ exprt summarizer_bw_termt::compute_precondition(
     solver << SSA.get_enabling_exprs();
     solver << postcond;
     exprt result=true_exprt();
-    if(solver()==decision_proceduret::D_UNSATISFIABLE)
+    if(solver()==decision_proceduret::resultt::D_UNSATISFIABLE)
       result=false_exprt();
     solver.pop_context();
     bw_transformer=result;

--- a/src/solver/summarizer_fw_contexts.cpp
+++ b/src/solver/summarizer_fw_contexts.cpp
@@ -77,10 +77,10 @@ void summarizer_fw_contextst::inline_summaries(
         // output calling context
         switch(ui)
         {
-        case ui_message_handlert::PLAIN:
+        case ui_message_handlert::uit::PLAIN:
           break;
 
-        case ui_message_handlert::XML_UI:
+        case ui_message_handlert::uit::XML_UI:
         {
           xmlt xml_cc("calling-context");
           xml_cc.set_attribute("function", id2string(fname));

--- a/src/solver/summarizer_fw_contexts.h
+++ b/src/solver/summarizer_fw_contexts.h
@@ -35,10 +35,10 @@ public:
     ssa_unwindert &_ssa_unwinder,
     ssa_inlinert &_ssa_inliner):
     summarizer_fwt(_options, _summary_db, _ssa_db, _ssa_unwinder, _ssa_inliner),
-    ui(ui_message_handlert::PLAIN)
+    ui(ui_message_handlert::uit::PLAIN)
   {
     if(_options.get_bool_option("xml-ui"))
-      ui=ui_message_handlert::XML_UI;
+      ui=ui_message_handlert::uit::XML_UI;
 
     optionst::value_listt _excluded_functions=
       _options.get_list_option("do-not-analyze-functions");

--- a/src/solver/summarizer_fw_term.cpp
+++ b/src/solver/summarizer_fw_term.cpp
@@ -34,8 +34,8 @@ void summarizer_fw_termt::compute_summary_rec(
   bool context_sensitive)
 {
   if(options.get_bool_option("competition-mode") &&
-     summary_db.exists(ID__start) &&
-     summary_db.get(ID__start).terminates==NO)
+     summary_db.exists(goto_functionst::entry_point()) &&
+     summary_db.get(goto_functionst::entry_point()).terminates==NO)
   {
     return;
   }

--- a/src/ssa/address_canonizer.cpp
+++ b/src/ssa/address_canonizer.cpp
@@ -9,7 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \file
 /// Canonize addresses of objects
 
-#include <ansi-c/c_types.h>
+#include <util/c_types.h>
 
 #include <util/std_expr.h>
 #include <util/pointer_offset_size.h>

--- a/src/ssa/local_ssa.h
+++ b/src/ssa/local_ssa.h
@@ -281,6 +281,7 @@ protected:
   void build_cond(locationt loc);
   void build_guard(locationt loc);
   void build_function_call(locationt loc);
+  bool get_deallocated_precondition(const exprt &expr, exprt &result);
   void build_assertions(locationt loc);
   void build_unknown_objs(locationt loc);
 

--- a/src/ssa/malloc_ssa.cpp
+++ b/src/ssa/malloc_ssa.cpp
@@ -15,8 +15,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/expr_util.h>
 #include <util/symbol.h>
 #include <util/pointer_offset_size.h>
+#include <util/c_types.h>
 
-#include <ansi-c/c_types.h>
 #include <analyses/constant_propagator.h>
 
 #include <functional>
@@ -93,6 +93,8 @@ std::vector<exprt> collect_pointer_vars(
   std::vector<exprt> pointers;
   forall_symbols(it, symbol_table.symbols)
   {
+    if(it->second.is_type)
+      continue;
     if(ns.follow(it->second.type).id()==ID_struct)
     {
       for(auto &component : to_struct_type(
@@ -321,7 +323,8 @@ bool replace_malloc(
              lhs_id=="__builtin_alloca::alloca_size")
           {
             namespacet ns(goto_model.symbol_table);
-            goto_functionst::goto_functiont function_copy=f_it->second;
+            goto_functionst::goto_functiont function_copy;
+            function_copy.copy_from(f_it->second);
             constant_propagator_ait const_propagator(function_copy, ns);
             forall_goto_program_instructions(copy_i_it, function_copy.body)
             {

--- a/src/ssa/ssa_build_goto_trace.cpp
+++ b/src/ssa/ssa_build_goto_trace.cpp
@@ -97,13 +97,13 @@ bool ssa_build_goto_tracet::record_step(
   case FUNCTION_CALL:
   case THROW:
   case CATCH:
-    step.type=goto_trace_stept::LOCATION;
+    step.type=goto_trace_stept::typet::LOCATION;
     goto_trace.add_step(step);
     step_nr++;
     break;
 
   case ASSUME:
-    step.type=goto_trace_stept::ASSUME;
+    step.type=goto_trace_stept::typet::ASSUME;
     step.cond_value=true;
     goto_trace.add_step(step);
     step_nr++;
@@ -116,7 +116,7 @@ bool ssa_build_goto_tracet::record_step(
     unwindable_local_SSA.rename(cond_read, current_pc);
     exprt cond_value=
       simplify_expr(prop_conv.get(cond_read), unwindable_local_SSA.ns);
-    step.type=goto_trace_stept::GOTO;
+    step.type=goto_trace_stept::typet::GOTO;
     step.cond_expr=cond_value; // cond
 #if 0
     assert(cond_value.is_true() || cond_value.is_false());
@@ -148,7 +148,7 @@ bool ssa_build_goto_tracet::record_step(
       simplify_expr(prop_conv.get(cond_read), unwindable_local_SSA.ns);
     if(cond_value.is_false())
     {
-      step.type=goto_trace_stept::ASSERT;
+      step.type=goto_trace_stept::typet::ASSERT;
       step.comment=id2string(current_pc->source_location.get_comment());
       step.cond_expr=cond;
       step.cond_value=false;
@@ -187,7 +187,7 @@ bool ssa_build_goto_tracet::record_step(
               << from_expr(unwindable_local_SSA.ns, "", rhs_simplified)
               << std::endl;
 #endif
-    step.type=goto_trace_stept::ASSIGNMENT;
+    step.type=goto_trace_stept::typet::ASSIGNMENT;
     step.full_lhs=lhs_simplified;
     step.full_lhs_value=rhs_simplified;
 
@@ -240,7 +240,7 @@ bool ssa_build_goto_tracet::record_step(
   break;
 
   case OTHER:
-    step.type=goto_trace_stept::LOCATION;
+    step.type=goto_trace_stept::typet::LOCATION;
     goto_trace.add_step(step);
     step_nr++;
     break;

--- a/src/ssa/ssa_dereference.cpp
+++ b/src/ssa/ssa_dereference.cpp
@@ -27,8 +27,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/base_type.h>
 #include <util/expr_util.h>
 #include <util/simplify_expr.h>
-
-#include <ansi-c/c_types.h>
+#include <util/c_types.h>
 
 #include "ssa_dereference.h"
 #include "address_canonizer.h"

--- a/src/ssa/ssa_object.cpp
+++ b/src/ssa/ssa_object.cpp
@@ -274,13 +274,13 @@ exprt ssa_objectt::get_root_object_rec(const exprt &src)
     return nil_exprt();
 }
 
-ssa_objectt::identifiert ssa_objectt::object_id_rec(
+irep_idt ssa_objectt::object_id_rec(
   const exprt &src,
   const namespacet &ns)
 {
   if(src.id()==ID_symbol)
   {
-    return identifiert(to_symbol_expr(src).get_identifier());
+    return irep_idt(to_symbol_expr(src).get_identifier());
   }
   else if(src.id()==ID_member)
   {
@@ -292,25 +292,25 @@ ssa_objectt::identifiert ssa_objectt::object_id_rec(
     {
       irep_idt compound_object=object_id_rec(compound_op, ns);
       if(compound_object==irep_idt())
-        return identifiert();
+        return irep_idt();
 
-      return identifiert(
+      return irep_idt(
         id2string(compound_object)+
         "."+id2string(member_expr.get_component_name()));
     }
     else
-      return identifiert();
+      return irep_idt();
   }
   else if(src.id()==ID_index)
   {
-    return identifiert();
+    return irep_idt();
   }
   else if(src.id()==ID_dereference)
   {
-    return identifiert();
+    return irep_idt();
   }
   else
-    return identifiert();
+    return irep_idt();
 }
 
 bool is_struct_member(const member_exprt &src, const namespacet &ns)

--- a/src/ssa/ssa_object.h
+++ b/src/ssa/ssa_object.h
@@ -18,19 +18,6 @@ Author: Daniel Kroening, kroening@kroening.com
 class ssa_objectt
 {
 public:
-  // type specialisation for object identifiers
-  class identifiert:public irep_idt
-  {
-  public:
-    inline explicit identifiert(const irep_idt &_src):irep_idt(_src)
-    {
-    }
-
-    inline identifiert()
-    {
-    }
-  };
-
   inline explicit ssa_objectt(const exprt &_expr, const namespacet &_ns):
     expr(_expr),
     identifier(object_id_rec(expr, _ns))
@@ -47,7 +34,7 @@ public:
     return expr;
   }
 
-  inline identifiert get_identifier() const
+  inline irep_idt get_identifier() const
   {
     return identifier;
   }
@@ -101,9 +88,9 @@ public:
 
 protected:
   exprt expr;
-  identifiert identifier;
+  irep_idt identifier;
 
-  static identifiert object_id_rec(const exprt &src, const namespacet &);
+  static irep_idt object_id_rec(const exprt &src, const namespacet &);
   static exprt get_root_object_rec(const exprt &);
 };
 


### PR DESCRIPTION
I will merge this PR similarly to the last one, this time in 3 commits - all the necessary fixes, commit https://github.com/diffblue/2ls/pull/149/commits/770d34969edf8d7f4dc7079096b7c7151c3637e6 (so that we can easily revert it once propagation is fixed) and commit updating version.

Related: https://github.com/peterschrammel/cbmc/pull/22

Changes
- minor renaming, some deprecations
- a lot of enums transformed into enum classes
- message_handler must not be NULL when get_message_handler is called, otherwise the program exits (fixed in https://github.com/diffblue/2ls/pull/149/commits/17d70420e448c399feaf207421cb961402d1f754)
- assertions generated by CBMC now have the form `FALSE || <assertion>`, this required fixes in https://github.com/diffblue/2ls/pull/149/commits/a0f6f5f2b51b345ecfb357b39f8564b393377b51 to make memsafety work.
- Messages from CBMC now contain typedefs instead of the typedef-ed structure, fixed this in test https://github.com/diffblue/2ls/pull/149/commits/2b4b91b13a198ddd1aa3427555ae775988e043ff
- Constant propagation is broken in CBMC 5.8, a lot of tests would be failing. So the best temporary solution turned out to be disabling constant propagation by default.