### PR TITLE
Update to CBMC 5.9

### DIFF
--- a/regression/memsafety/built_from_end/test.desc
+++ b/regression/memsafety/built_from_end/test.desc
@@ -1,6 +1,35 @@
-CORE
+KNOWNBUG
 main.c
 --heap --intervals --pointer-check --no-assertions
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
+--
+--
+CBMC 5.9 introduced changes to its implementation of some built-in functions,
+the ones affecting this test are malloc and free. Malloc changes have been
+already accounted for in 2LS codebase, however the control flow of free
+is most likely causing problems in this test making one of the asserts fail:
+
+[main.pointer_dereference.27] dereference failure: deallocated dynamic object in *p: UNKNOWN
+
+This may be related to double free assertion, where GOTO changed from:
+
+...
+    IF !(__CPROVER_deallocated == ptr) THEN GOTO 6
+    // 144 file <builtin-library-free> line 18 function free
+    ASSERT 0 != 0 // double free
+    // 145 no location
+    ASSUME 0 != 0
+    // 146 file <builtin-library-free> line 29 function free
+ 6: _Bool record;
+...
+
+to:
+    ASSERT ptr == NULL || __CPROVER_deallocated != ptr // double free
+
+Note the new ptr == NULL condition, this could be the root cause of
+the problem. However further investigation is required
+and will be done once the CBMC rebase is completed. According to the
+C standard, free(NULL) is a valid construct (no operation) but 2LS doesn't
+seem to handle this case correctly.

--- a/regression/memsafety/simple_true/test.desc
+++ b/regression/memsafety/simple_true/test.desc
@@ -1,6 +1,36 @@
-CORE
+KNOWNBUG
 main.c
 --heap --intervals --pointer-check --no-assertions
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
+--
+--
+CBMC 5.9 introduced changes to its implementation of some built-in functions,
+the ones affecting this test are malloc and free. Malloc changes have been
+already accounted for in 2LS codebase, however the control flow of free
+is most likely causing problems in this test making one of the asserts fail:
+
+[main.pointer_dereference.27] dereference failure: deallocated dynamic object in *p: UNKNOWN
+
+This may be related to double free assertion, where GOTO changed from:
+
+...
+    IF !(__CPROVER_deallocated == ptr) THEN GOTO 6
+    // 144 file <builtin-library-free> line 18 function free
+    ASSERT 0 != 0 // double free
+    // 145 no location
+    ASSUME 0 != 0
+    // 146 file <builtin-library-free> line 29 function free
+ 6: _Bool record;
+...
+
+to:
+    ASSERT ptr == NULL || __CPROVER_deallocated != ptr // double free
+
+Note the new ptr == NULL condition, this could be the root cause of
+the problem. However further investigation is required
+and will be done once the CBMC rebase is completed. According to the
+C standard, free(NULL) is a valid construct (no operation) but 2LS doesn't
+seem to handle this case correctly.
+

--- a/regression/termination/locks1/test.desc
+++ b/regression/termination/locks1/test.desc
@@ -1,6 +1,10 @@
-CORE
+KNOWNBUG
 main.c
 --inline
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
+--
+--
+This test is broken with CBMC 5.9 due to constant-propagation.
+Running it with --no-propagation works as expected

--- a/src/2ls/2ls_languages.cpp
+++ b/src/2ls/2ls_languages.cpp
@@ -13,7 +13,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <ansi-c/ansi_c_language.h>
 #include <cpp/cpp_language.h>
-#include <java_bytecode/java_bytecode_language.h>
 
 #include "2ls_parse_options.h"
 

--- a/src/2ls/2ls_parse_options.h
+++ b/src/2ls/2ls_parse_options.h
@@ -60,31 +60,28 @@ class optionst;
   "(show-locs)(show-vcc)(show-properties)(trace)(show-stats)" \
   "(show-goto-functions)(show-guards)(show-defs)(show-ssa)(show-assignments)" \
   "(show-invariants)(std-invariants)" \
+  "(show-symbol-table)" \
   "(property):(all-properties)(k-induction)(incremental-bmc)" \
   "(no-spurious-check)(all-functions)" \
   "(no-simplify)(no-fixed-point)" \
   "(graphml-witness):(json-cex):" \
   "(no-spurious-check)(stop-on-fail)" \
   "(competition-mode)(slice)(no-propagation)(independent-properties)" \
-  "(constant-propagation)" \
   "(no-unwinding-assertions)"
   // the last line is for CBMC-regression testing only
 
 class twols_parse_optionst:
   public parse_options_baset,
-  public language_uit
+  public messaget
 {
 public:
   virtual int doit();
   virtual void help();
 
   twols_parse_optionst(int argc, const char **argv);
-  twols_parse_optionst(
-    int argc,
-    const char **argv,
-    const std::string &extra_options);
 
 protected:
+  goto_modelt goto_model;
   ui_message_handlert ui_message_handler;
   bool recursion_detected;
   bool threads_detected;
@@ -93,9 +90,7 @@ protected:
 
   void get_command_line_options(optionst &options);
 
-  bool get_goto_program(
-    const optionst &options,
-    goto_modelt &goto_model);
+  bool get_goto_program(const optionst &options);
 
   bool process_goto_program(
     const optionst &options,
@@ -163,8 +158,6 @@ protected:
   void eval_verbosity();
   void report_unknown();
 
-  void require_entry(const goto_modelt &goto_model);
-
   bool has_threads(const goto_modelt &goto_model);
 
   // diverse preprocessing
@@ -172,11 +165,6 @@ protected:
   void propagate_constants(goto_modelt &goto_model);
   void nondet_locals(goto_modelt &goto_model);
   bool unwind_goto_into_loop(goto_modelt &goto_model, unsigned k);
-  void replace_types_rec(const replace_symbolt &replace_const, exprt &expr);
-  exprt evaluate_casts_in_constants(
-    const exprt &expr,
-    const typet &parent_type,
-    bool &valid);
   void remove_multiple_dereferences(goto_modelt &goto_model);
   void remove_multiple_dereferences(
     goto_modelt &goto_model,

--- a/src/2ls/Makefile
+++ b/src/2ls/Makefile
@@ -26,6 +26,7 @@ OBJ+= $(CPROVER_DIR)/src/ansi-c/ansi-c$(LIBEXT) \
       $(CPROVER_DIR)/src/solvers/solvers$(LIBEXT) \
       $(CPROVER_DIR)/src/util/util$(LIBEXT) \
       $(CPROVER_DIR)/src/goto-instrument/unwind$(OBJEXT) \
+      $(CPROVER_DIR)/src/goto-instrument/unwindset$(OBJEXT) \
       ../domains/domains$(LIBEXT) \
       ../ssa/ssa$(LIBEXT) \
       ../solver/solver$(LIBEXT) \

--- a/src/2ls/instrument_goto.cpp
+++ b/src/2ls/instrument_goto.cpp
@@ -140,17 +140,11 @@ void instrument_gotot::operator()(goto_modelt &goto_model)
 {
   goto_functionst &goto_functions=goto_model.goto_functions;
 
-  typedef goto_functions_templatet<goto_programt>::function_mapt
-    function_mapt;
+  goto_functionst::function_mapt  &function_map=goto_functions.function_map;
 
-  function_mapt &function_map=goto_functions.function_map;
-
-  for(function_mapt::iterator
-      fit=function_map.begin();
-      fit!=function_map.end();
-      ++fit)
+  for(auto & fit : function_map)
   {
-    instrument_function(fit->first, fit->second);
+    instrument_function(fit.first, fit.second);
   }
 
   goto_model.goto_functions.update();

--- a/src/2ls/summary_checker_base.cpp
+++ b/src/2ls/summary_checker_base.cpp
@@ -506,7 +506,6 @@ void summary_checker_baset::instrument_and_output(
   status() << "Writing instrumented goto-binary " << filename << eom;
   write_goto_binary(
     filename,
-    goto_model.symbol_table,
-    goto_model.goto_functions,
+    goto_model,
     get_message_handler());
 }

--- a/src/2ls/summary_checker_base.h
+++ b/src/2ls/summary_checker_base.h
@@ -12,7 +12,6 @@ Author: Peter Schrammel
 #ifndef CPROVER_2LS_2LS_SUMMARY_CHECKER_BASE_H
 #define CPROVER_2LS_2LS_SUMMARY_CHECKER_BASE_H
 
-#include <util/time_stopping.h>
 #include <goto-programs/property_checker.h>
 #include <solvers/prop/prop_conv.h>
 
@@ -56,10 +55,6 @@ public:
     messaget::set_message_handler(_message_handler);
     ssa_inliner.set_message_handler(_message_handler);
   }
-
-  // statistics
-  absolute_timet start_time;
-  time_periodt sat_time;
 
 protected:
   optionst &options;

--- a/src/2ls/version.h
+++ b/src/2ls/version.h
@@ -12,6 +12,6 @@ Author: Peter Schrammel
 #ifndef CPROVER_2LS_2LS_VERSION_H
 #define CPROVER_2LS_2LS_VERSION_H
 
-#define TWOLS_VERSION "0.9.3"
+#define TWOLS_VERSION "0.9.4"
 
 #endif

--- a/src/domains/equality_domain.cpp
+++ b/src/domains/equality_domain.cpp
@@ -11,7 +11,6 @@ Author: Peter Schrammel
 
 #ifdef DEBUG
 #include <iostream>
-#include <langapi/languages.h>
 #endif
 
 #include <util/find_symbols.h>

--- a/src/domains/incremental_solver.h
+++ b/src/domains/incremental_solver.h
@@ -152,11 +152,14 @@ class incremental_solvert:public messaget
 #ifdef NON_INCREMENTAL
     solver=new bv_pointerst(ns, *sat_check);
 #else
-    solver=new bv_refinementt(ns, *sat_check);
+    bv_refinementt::infot info;
+    info.ns=&ns;
+    info.prop=sat_check;
+    info.refine_arrays=false;
+    info.refine_arithmetic=arith_refinement;
+
+    solver=new bv_refinementt(info);
     solver->set_all_frozen();
-    static_cast<bv_refinementt *>(solver)->do_array_refinement=false;
-    static_cast<bv_refinementt *>(solver)->do_arithmetic_refinement=
-      arith_refinement;
 #endif
   }
 

--- a/src/domains/lexlinrank_domain.cpp
+++ b/src/domains/lexlinrank_domain.cpp
@@ -15,8 +15,7 @@ Author: Peter Schrammel
 
 #include <util/find_symbols.h>
 #include <util/simplify_expr.h>
-#include <langapi/languages.h>
-#include <goto-symex/adjust_float_expressions.h>
+#include <goto-programs/adjust_float_expressions.h>
 
 #include <util/cprover_prefix.h>
 #include "lexlinrank_domain.h"

--- a/src/domains/linrank_domain.cpp
+++ b/src/domains/linrank_domain.cpp
@@ -15,9 +15,8 @@ Author: Peter Schrammel
 
 #include <util/find_symbols.h>
 #include <util/simplify_expr.h>
-#include <langapi/languages.h>
 #include <util/cprover_prefix.h>
-#include <goto-symex/adjust_float_expressions.h>
+#include <goto-programs/adjust_float_expressions.h>
 
 #include "linrank_domain.h"
 #include "util.h"

--- a/src/domains/predabs_domain.cpp
+++ b/src/domains/predabs_domain.cpp
@@ -16,7 +16,6 @@ Author: Peter Schrammel
 #include <util/find_symbols.h>
 #include <util/prefix.h>
 #include <util/simplify_expr.h>
-#include <langapi/languages.h>
 
 #include "predabs_domain.h"
 #include "util.h"

--- a/src/domains/strategy_solver_simple.cpp
+++ b/src/domains/strategy_solver_simple.cpp
@@ -11,7 +11,7 @@ Author: Matej Marusak
 
 #include <ssa/ssa_inliner.h>
 #include "strategy_solver_simple.h"
-#include <goto-symex/adjust_float_expressions.h>
+#include <goto-programs/adjust_float_expressions.h>
 
 bool strategy_solver_simplet::iterate(invariantt &_inv)
 {

--- a/src/domains/tpolyhedra_domain.cpp
+++ b/src/domains/tpolyhedra_domain.cpp
@@ -11,7 +11,6 @@ Author: Peter Schrammel
 
 #ifdef DEBUG
 #include <iostream>
-#include <langapi/languages.h>
 #endif
 
 #include <util/find_symbols.h>

--- a/src/solver/summarizer_base.h
+++ b/src/solver/summarizer_base.h
@@ -14,7 +14,6 @@ Author: Peter Schrammel
 
 #include <util/message.h>
 #include <util/options.h>
-#include <util/time_stopping.h>
 
 #include <ssa/ssa_inliner.h>
 #include <ssa/ssa_unwinder.h>

--- a/src/solver/summarizer_bw.h
+++ b/src/solver/summarizer_bw.h
@@ -14,7 +14,6 @@ Author: Peter Schrammel
 
 #include <util/message.h>
 #include <util/options.h>
-#include <util/time_stopping.h>
 
 #include <ssa/ssa_inliner.h>
 #include <ssa/ssa_unwinder.h>

--- a/src/solver/summarizer_bw_term.h
+++ b/src/solver/summarizer_bw_term.h
@@ -14,7 +14,6 @@ Author: Peter Schrammel
 
 #include <util/message.h>
 #include <util/options.h>
-#include <util/time_stopping.h>
 
 #include <ssa/ssa_inliner.h>
 #include <ssa/ssa_unwinder.h>

--- a/src/solver/summarizer_fw.h
+++ b/src/solver/summarizer_fw.h
@@ -14,7 +14,6 @@ Author: Peter Schrammel
 
 #include <util/message.h>
 #include <util/options.h>
-#include <util/time_stopping.h>
 
 #include <ssa/ssa_inliner.h>
 #include <ssa/ssa_unwinder.h>

--- a/src/solver/summarizer_fw_contexts.h
+++ b/src/solver/summarizer_fw_contexts.h
@@ -15,7 +15,6 @@ Author: Peter Schrammel
 #include <util/message.h>
 #include <util/options.h>
 #include <langapi/language_ui.h>
-#include <util/time_stopping.h>
 
 #include <ssa/ssa_inliner.h>
 #include <ssa/ssa_unwinder.h>

--- a/src/solver/summarizer_fw_term.h
+++ b/src/solver/summarizer_fw_term.h
@@ -14,7 +14,6 @@ Author: Peter Schrammel
 
 #include <util/message.h>
 #include <util/options.h>
-#include <util/time_stopping.h>
 
 #include <ssa/ssa_inliner.h>
 #include <ssa/ssa_unwinder.h>

--- a/src/ssa/address_canonizer.cpp
+++ b/src/ssa/address_canonizer.cpp
@@ -13,9 +13,12 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/std_expr.h>
 #include <util/pointer_offset_size.h>
+#include <util/config.h>
 
 #include "address_canonizer.h"
 #include "ssa_pointed_objects.h"
+
+extern configt config;
 
 exprt address_canonizer(
   const exprt &address,
@@ -44,7 +47,9 @@ exprt address_canonizer(
       address_of_exprt address_of_expr(to_member_expr(object).struct_op());
       exprt rec_result=address_canonizer(address_of_expr, ns); // rec. call
 
-      pointer_typet byte_pointer(unsigned_char_type());
+      pointer_typet byte_pointer(
+        unsigned_char_type(),
+        config.ansi_c.pointer_width);
       typecast_exprt typecast_expr(rec_result, byte_pointer);
       plus_exprt sum(typecast_expr, offset);
       if(sum.type()!=address.type())
@@ -58,8 +63,7 @@ exprt address_canonizer(
       address_of_exprt address_of_expr(to_index_expr(object).array());
       exprt rec_result=address_canonizer(address_of_expr, ns); // rec. call
 
-      pointer_typet pointer_type;
-      pointer_type.subtype()=object.type();
+      pointer_typet pointer_type(object.type(), config.ansi_c.pointer_width);
       typecast_exprt typecast_expr(rec_result, pointer_type);
       plus_exprt sum(typecast_expr, to_index_expr(object).index());
       if(sum.type()!=address.type())

--- a/src/ssa/local_ssa.cpp
+++ b/src/ssa/local_ssa.cpp
@@ -21,7 +21,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/decision_procedure.h>
 #include <util/byte_operators.h>
 
-#include <goto-symex/adjust_float_expressions.h>
+#include <goto-programs/adjust_float_expressions.h>
 
 #include "local_ssa.h"
 #include "ssa_dereference.h"
@@ -415,7 +415,7 @@ void local_SSAt::build_function_call(locationt loc)
 
     // turn function call into expression
     function_application_exprt f;
-    f.function()=code_function_call.function();
+    f.function()=to_symbol_expr(code_function_call.function());
     f.type()=code_function_call.lhs().type();
     f.arguments()=code_function_call.arguments();
 
@@ -921,7 +921,7 @@ void local_SSAt::replace_side_effects_rec(
       exprt s=nondet_symbol("ssa::nondet", expr.type(), loc, counter);
       expr.swap(s);
     }
-    else if(statement==ID_malloc)
+    else if(statement==ID_allocate)
     {
       assert(false);
 /*      counter++;

--- a/src/ssa/may_alias_analysis.h
+++ b/src/ssa/may_alias_analysis.h
@@ -44,6 +44,16 @@ public:
     make_top();
   }
 
+  bool is_bottom() const override
+  {
+    return has_values.is_false();
+  }
+
+  bool is_top() const override
+  {
+    return has_values.is_true();
+  }
+
   typedef union_find<irep_idt> aliasest;
   aliasest aliases;
 

--- a/src/ssa/ssa_domain.h
+++ b/src/ssa/ssa_domain.h
@@ -108,6 +108,16 @@ public:
     has_values=tvt(true);
   }
 
+  bool is_bottom() const override
+  {
+    return has_values.is_false();
+  }
+
+  bool is_top() const override
+  {
+    return has_values.is_true();
+  }
+
 protected:
   tvt has_values;
 

--- a/src/ssa/ssa_object.cpp
+++ b/src/ssa/ssa_object.cpp
@@ -239,7 +239,7 @@ void ssa_objectst::categorize_objects(
       }
       else
       {
-        const symbolt &symbol=ns.lookup(root_object);
+        const symbolt &symbol=ns.lookup(to_symbol_expr(root_object));
         if(symbol.is_procedure_local())
         {
           if(dirty(symbol.name))

--- a/src/ssa/ssa_pointed_objects.cpp
+++ b/src/ssa/ssa_pointed_objects.cpp
@@ -9,6 +9,8 @@ Author: Viktor Malik
 /// \file
 /// Library of functions for working with pointed objects
 
+#include <util/c_types.h>
+
 #include "ssa_pointed_objects.h"
 #include "ssa_object.h"
 
@@ -138,7 +140,7 @@ const exprt get_pointer(const exprt &expr, unsigned level)
   {
     pointer=symbol_exprt(
       expr.get(level_str(level, ID_pointer_sym)),
-      pointer_typet(pointed_type));
+      pointer_type(pointed_type));
     copy_pointed_info(pointer, expr, level-1);
   }
   else
@@ -151,7 +153,7 @@ const exprt get_pointer(const exprt &expr, unsigned level)
     pointer=member_exprt(
       compound,
       pointer_level_field(expr, level),
-      pointer_typet(pointed_type));
+      pointer_type(pointed_type));
   }
   return pointer;
 }

--- a/src/ssa/ssa_value_set.h
+++ b/src/ssa/ssa_value_set.h
@@ -45,6 +45,16 @@ public:
     make_top();
   }
 
+  bool is_bottom() const override
+  {
+    return has_values.is_false();
+  }
+
+  bool is_top() const override
+  {
+    return has_values.is_true();
+  }
+
   struct valuest
   {
   public:


### PR DESCRIPTION
Related: https://github.com/peterschrammel/cbmc/pull/23

Changes:
 - domains must now implement is_bottom and is_top methods
 - ID_malloc deprecated
 - some changes to exprt constructors
 - union_fidn can no longer be inherited from, fixed by using it as an attribute
 - CBMC_VERSION is now passed to CBMC during compilation which seems to make it impossible to mention it in the help message
 - GOTO program reading simplification
 - Constant propagation now works as expected (except for one test where it produces a wrong result) so I decided to re-enable it

Also memsafety tests which are correct are broken (one of the assertions failed). We tried to investigate the problem with @viktormalik and it seems to be related to changes in CBMC free implementation. Fixing this may be difficult so we agreed that it may be a good idea to leave it for a stable version (once the rebase is finished).