### PR TITLE
Update to CBMC 5.12

### DIFF
--- a/regression/memsafety/built_from_end_false/test.desc
+++ b/regression/memsafety/built_from_end_false/test.desc
@@ -4,4 +4,4 @@ main.c
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
-\[main.pointer_dereference.17\] dereference failure: deallocated dynamic object in \*\(\(List\)\(char \*\)\(\(char \*\)p \+ \(signed long int\)8ul\)\): FAILURE
+\[main.pointer_dereference.17\] dereference failure: deallocated dynamic object in p->n: FAILURE

--- a/regression/memsafety/simple_false/test.desc
+++ b/regression/memsafety/simple_false/test.desc
@@ -4,4 +4,4 @@ main.c
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
-\[main.pointer_dereference.38\] dereference failure: deallocated dynamic object in \*\(\(List\)\(char \*\)\(\(char \*\)p \+ \(signed long int\)8ul\)\): FAILURE
+\[main.pointer_dereference.38\] dereference failure: deallocated dynamic object in p->n: FAILURE

--- a/regression/termination/precond_term1/test.desc
+++ b/regression/termination/precond_term1/test.desc
@@ -1,6 +1,17 @@
-CORE
+KNOWNBUG
 main.c
 --preconditions
 ^EXIT=5$
 ^SIGNAL=0$
 \[__CPROVER__start\]: !\(argc' <= 1 && -\(\(signed __CPROVER_bitvector\[33\]\)argc'\) <= -1\)
+--
+--
+CBMC 5.12 introduced significant changes to solvers and this test failure
+seems to be one of its consequences. The formulae pushed into the solver
+seem to be identical to the previous 2LS version, however the solver in
+SSA analyzer then throws UNSAT on the first iteration when doing
+backward analysis (the invariants up until that point are correct)
+resulting in no improvements done to the template.
+
+This problem will require further investigation once the CBMC rebase
+is complete

--- a/src/2ls/2ls_parse_options.h
+++ b/src/2ls/2ls_parse_options.h
@@ -16,8 +16,6 @@ Author: Daniel Kroening, Peter Schrammel
 #include <util/parse_options.h>
 #include <util/replace_symbol.h>
 
-#include <langapi/language_ui.h>
-
 #include <analyses/goto_check.h>
 #include <ssa/dynobj_instance_analysis.h>
 
@@ -104,7 +102,8 @@ protected:
   void report_properties(
     const optionst &options,
     const goto_modelt &,
-    const summary_checker_baset::property_mapt &);
+    const propertiest &,
+    const tracest &traces);
 
   void show_counterexample(
     const goto_modelt &,

--- a/src/2ls/Makefile
+++ b/src/2ls/Makefile
@@ -27,6 +27,7 @@ OBJ+= $(CPROVER_DIR)/src/ansi-c/ansi-c$(LIBEXT) \
       $(CPROVER_DIR)/src/util/util$(LIBEXT) \
       $(CPROVER_DIR)/src/goto-instrument/unwind$(OBJEXT) \
       $(CPROVER_DIR)/src/goto-instrument/unwindset$(OBJEXT) \
+      $(CPROVER_DIR)/src/goto-checker/goto-checker$(LIBEXT) \
       ../domains/domains$(LIBEXT) \
       ../ssa/ssa$(LIBEXT) \
       ../solver/solver$(LIBEXT) \

--- a/src/2ls/cover_goals_ext.cpp
+++ b/src/2ls/cover_goals_ext.cpp
@@ -130,14 +130,15 @@ void cover_goals_extt::assignment()
     for(goal_mapt::const_iterator it=goal_map.begin();
         it!=goal_map.end(); it++, g_it++)
     {
-      if(property_map[it->first].result==property_checkert::resultt::UNKNOWN &&
+      if((property_map.at(it->first).status==property_statust::UNKNOWN ||
+          property_map.at(it->first).status==property_statust::NOT_CHECKED) &&
          solver.l_get(g_it->condition).is_true())
       {
-        property_map[it->first].result=property_checkert::resultt::FAIL;
+        property_map.at(it->first).status=property_statust::FAIL;
         if(build_error_trace)
         {
           ssa_build_goto_tracet build_goto_trace(SSA, solver.get_solver());
-          build_goto_trace(property_map[it->first].error_trace);
+          build_goto_trace(traces[it->first]);
           if(!all_properties)
             break;
         }
@@ -159,14 +160,15 @@ void cover_goals_extt::assignment()
     for(goal_mapt::const_iterator it=goal_map.begin();
         it!=goal_map.end(); it++, g_it++)
     {
-      if(property_map[it->first].result==property_checkert::resultt::UNKNOWN &&
+      if((property_map.at(it->first).status==property_statust::UNKNOWN ||
+          property_map.at(it->first).status==property_statust::NOT_CHECKED) &&
          solver.l_get(g_it->condition).is_true())
       {
-        property_map[it->first].result=property_checkert::resultt::FAIL;
+        property_map.at(it->first).status=property_statust::FAIL;
         if(build_error_trace)
         {
           ssa_build_goto_tracet build_goto_trace(SSA, solver.get_solver());
-          build_goto_trace(property_map[it->first].error_trace);
+          build_goto_trace(traces[it->first]);
 
 #if 0
           show_raw_countermodel(

--- a/src/2ls/cover_goals_ext.h
+++ b/src/2ls/cover_goals_ext.h
@@ -13,11 +13,12 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_2LS_2LS_COVER_GOALS_EXT_H
 
 #include <util/message.h>
-#include <goto-programs/property_checker.h>
+#include <goto-checker/properties.h>
 
 #include "../ssa/local_ssa.h"
 #include "../ssa/unwindable_local_ssa.h"
 #include "../domains/incremental_solver.h"
+#include "traces.h"
 
 /// Try to cover some given set of goals incrementally. This can be seen as a
 /// heuristic variant of SAT-based set-cover. No minimality guarantee.
@@ -46,13 +47,15 @@ public:
     unwindable_local_SSAt &_SSA,
     incremental_solvert &_solver,
     const exprt::operandst& _loophead_selects,
-    property_checkert::property_mapt &_property_map,
+    propertiest &_property_map,
+    tracest &_traces,
     bool _spurious_check,
     bool _all_properties,
     bool _build_error_trace):
     SSA(_SSA),
     solver(_solver),
     property_map(_property_map),
+    traces(_traces),
     spurious_check(_spurious_check),
     all_properties(_all_properties),
     build_error_trace(_build_error_trace),
@@ -111,7 +114,8 @@ protected:
   unwindable_local_SSAt &SSA;
   unsigned _number_covered, _iterations;
   incremental_solvert &solver;
-  property_checkert::property_mapt &property_map;
+  propertiest &property_map;
+  tracest &traces;
   bool spurious_check, all_properties, build_error_trace;
   exprt::operandst loophead_selects;
 

--- a/src/2ls/graphml_witness_ext.cpp
+++ b/src/2ls/graphml_witness_ext.cpp
@@ -57,7 +57,7 @@ void graphml_witness_extt::operator()(
       continue;
     }
 
-    const graphmlt::node_indext node=add_node(cfg[i]);
+    const graphmlt::node_indext node=add_node(cfg[i], function_name);
     index_map[i]=node;
   }
   for(std::size_t i=0; i<cfg.size(); ++i)
@@ -71,7 +71,8 @@ void graphml_witness_extt::operator()(
 }
 
 graphmlt::node_indext graphml_witness_extt::add_node(
-  const dynamic_cfg_nodet &cfg_node)
+  const dynamic_cfg_nodet &cfg_node,
+  const irep_idt &function_identifier)
 {
   const graphmlt::node_indext node=graphml.add_node();
   graphml[node].node_name=cfg_node.id.to_string();
@@ -81,7 +82,7 @@ graphmlt::node_indext graphml_witness_extt::add_node(
     std::ostringstream invs;
     invs << from_expr(ns, "", cfg_node.assumption);
     graphml[node].invariant=invs.str();
-    graphml[node].invariant_scope=id2string(cfg_node.id.pc->function);
+    graphml[node].invariant_scope=id2string(function_identifier);
   }
   return node;
 }

--- a/src/2ls/graphml_witness_ext.h
+++ b/src/2ls/graphml_witness_ext.h
@@ -30,11 +30,6 @@ public:
   void operator()(const summary_checker_baset &summary_checker);
 
 protected:
-  graphmlt::node_indext add_node(
-    std::map<unsigned,
-    unsigned> &loc_to_node,
-    goto_programt::const_targett it);
-
   void add_edge(
     const graphmlt::node_indext &from,
     const dynamic_cfg_nodet &from_cfg_node,
@@ -42,7 +37,8 @@ protected:
     const dynamic_cfg_nodet &to_cfg_node);
 
   graphmlt::node_indext add_node(
-    const dynamic_cfg_nodet &cfg_node);
+    const dynamic_cfg_nodet &cfg_node,
+    const irep_idt &function_identifier);
 };
 
 #endif // CPROVER_2LS_SUMMARIZER_GRAPHML_WITNESS_EXT_H

--- a/src/2ls/show.cpp
+++ b/src/2ls/show.cpp
@@ -94,7 +94,7 @@ void show_defs(
     ssa_value_ai);
   ssa_ait ssa_analysis(assignments);
   ssa_analysis(function_identifier, goto_function, ns);
-  ssa_analysis.output(ns, goto_function.body, out);
+  ssa_analysis.output(ns, goto_function, out);
 }
 
 void show_defs(

--- a/src/2ls/summary_checker_ai.cpp
+++ b/src/2ls/summary_checker_ai.cpp
@@ -12,7 +12,7 @@ Author: Peter Schrammel
 #include "summary_checker_ai.h"
 #include <ssa/ssa_build_goto_trace.h>
 
-property_checkert::resultt summary_checker_ait::operator()(
+resultt summary_checker_ait::operator()(
   const goto_modelt &goto_model)
 {
   SSA_functions(goto_model, goto_model.symbol_table);
@@ -30,9 +30,10 @@ property_checkert::resultt summary_checker_ait::operator()(
   }
 
   // properties
-  initialize_property_map(goto_model.goto_functions);
+  property_map=initialize_properties(goto_model);
+  set_properties_unknown();
 
-  property_checkert::resultt result=property_checkert::resultt::UNKNOWN;
+  resultt result=resultt::UNKNOWN;
   bool finished=false;
   while(!finished)
   {
@@ -54,7 +55,7 @@ property_checkert::resultt summary_checker_ait::operator()(
     {
       report_statistics();
       report_preconditions();
-      return property_checkert::resultt::UNKNOWN;
+      return resultt::UNKNOWN;
     }
 
     if(termination)
@@ -65,13 +66,13 @@ property_checkert::resultt summary_checker_ait::operator()(
 
 #ifdef SHOW_CALLINGCONTEXTS
     if(options.get_bool_option("show-calling-contexts"))
-      return property_checkert::resultt::UNKNOWN;
+      return resultt::UNKNOWN;
 #endif
 
     result=check_properties();
     report_statistics();
 
-    if(result==property_checkert::resultt::UNKNOWN &&
+    if(result==resultt::UNKNOWN &&
        options.get_bool_option("values-refine") &&
        options.get_bool_option("intervals"))
     {
@@ -110,7 +111,7 @@ void summary_checker_ait::report_preconditions()
   }
 }
 
-property_checkert::resultt summary_checker_ait::report_termination()
+resultt summary_checker_ait::report_termination()
 {
   result() << eom;
   result() << "** Termination: " << eom;
@@ -134,17 +135,17 @@ property_checkert::resultt summary_checker_ait::report_termination()
        << (!computed ? "not computed" : threeval2string(terminates)) << eom;
   }
   if(not_computed)
-    return property_checkert::resultt::UNKNOWN;
+    return resultt::UNKNOWN;
   if(all_terminate)
-    return property_checkert::resultt::PASS;
+    return resultt::PASS;
   if(one_nonterminate)
   {
 #if 0
-    return property_checkert::resultt::FAIL;
+    return resultt::FAIL;
 #else
     // rely on nontermination checker to find counterexample
-    return property_checkert::resultt::UNKNOWN;
+    return resultt::UNKNOWN;
 #endif
   }
-  return property_checkert::resultt::UNKNOWN;
+  return resultt::UNKNOWN;
 }

--- a/src/2ls/summary_checker_ai.h
+++ b/src/2ls/summary_checker_ai.h
@@ -24,7 +24,7 @@ public:
 
 protected:
   void report_preconditions();
-  property_checkert::resultt report_termination();
+  resultt report_termination();
 };
 
 #endif

--- a/src/2ls/summary_checker_bmc.cpp
+++ b/src/2ls/summary_checker_bmc.cpp
@@ -12,14 +12,14 @@ Author: Peter Schrammel
 #include "summary_checker_bmc.h"
 
 
-property_checkert::resultt summary_checker_bmct::operator()(
+resultt summary_checker_bmct::operator()(
   const goto_modelt &goto_model)
 {
   SSA_functions(goto_model, goto_model.symbol_table);
 
   ssa_unwinder.init(false, true);
 
-  property_checkert::resultt result=property_checkert::resultt::UNKNOWN;
+  resultt result=resultt::UNKNOWN;
   unsigned max_unwind=options.get_unsigned_int_option("unwind");
   status() << "Max-unwind is " << max_unwind << eom;
   ssa_unwinder.init_localunwinders();
@@ -30,13 +30,13 @@ property_checkert::resultt summary_checker_bmct::operator()(
     summary_db.mark_recompute_all();
     ssa_unwinder.unwind_all(unwind);
     result=check_properties();
-    if(result==property_checkert::resultt::PASS)
+    if(result==resultt::PASS)
     {
       status() << "incremental BMC proof found after "
          << unwind << " unwinding(s)" << messaget::eom;
       break;
     }
-    else if(result==property_checkert::resultt::FAIL)
+    else if(result==resultt::FAIL)
     {
       status() << "incremental BMC counterexample found after "
          << unwind << " unwinding(s)" << messaget::eom;

--- a/src/2ls/summary_checker_kind.cpp
+++ b/src/2ls/summary_checker_kind.cpp
@@ -11,14 +11,14 @@ Author: Peter Schrammel
 
 #include "summary_checker_kind.h"
 
-property_checkert::resultt summary_checker_kindt::operator()(
+resultt summary_checker_kindt::operator()(
   const goto_modelt &goto_model)
 {
   SSA_functions(goto_model, goto_model.symbol_table);
 
   ssa_unwinder.init(true, false);
 
-  property_checkert::resultt result=property_checkert::resultt::UNKNOWN;
+  resultt result=resultt::UNKNOWN;
   unsigned max_unwind=options.get_unsigned_int_option("unwind");
   unsigned give_up_invariants=
     options.get_unsigned_int_option("give-up-invariants");
@@ -38,21 +38,20 @@ property_checkert::resultt summary_checker_kindt::operator()(
     bool magic_limit_not_reached=
       unwind<give_up_invariants ||
       !options.get_bool_option("competition-mode");
-    if(result==property_checkert::resultt::UNKNOWN &&
-       !options.get_bool_option("havoc") &&
+    if(result==resultt::UNKNOWN && !options.get_bool_option("havoc") &&
        magic_limit_not_reached)
     {
       summarize(goto_model);
       result=check_properties();
     }
 
-    if(result==property_checkert::resultt::PASS)
+    if(result==resultt::PASS)
     {
       status() << "k-induction proof found after "
          << unwind << " unwinding(s)" << eom;
       break;
     }
-    else if(result==property_checkert::resultt::FAIL)
+    else if(result==resultt::FAIL)
     {
       status() << "k-induction counterexample found after "
          << unwind << " unwinding(s)" << eom;

--- a/src/2ls/summary_checker_nonterm.h
+++ b/src/2ls/summary_checker_nonterm.h
@@ -31,7 +31,7 @@ public:
     const ssa_dbt::functionst::const_iterator f_it);
 
 protected:
-  summary_checker_baset::resultt check_nonterm_linear();
+  resultt check_nonterm_linear();
 };
 
 #endif // CPROVER_2LS_2LS_SUMMARY_CHECKER_NONTERM_H

--- a/src/2ls/traces.h
+++ b/src/2ls/traces.h
@@ -1,0 +1,17 @@
+/*******************************************************************\
+
+Module: GOTO traces
+
+Author: František Nečas
+
+\*******************************************************************/
+
+/// \file
+/// GOTO traces
+
+#ifndef CPROVER_2LS_2LS_TYPES_H
+#define CPROVER_2LS_2LS_TYPES_H
+
+typedef std::unordered_map<irep_idt, goto_tracet> tracest;
+
+#endif

--- a/src/2ls/version.h
+++ b/src/2ls/version.h
@@ -12,6 +12,6 @@ Author: Peter Schrammel
 #ifndef CPROVER_2LS_2LS_VERSION_H
 #define CPROVER_2LS_2LS_VERSION_H
 
-#define TWOLS_VERSION "0.9.5"
+#define TWOLS_VERSION "0.9.6"
 
 #endif

--- a/src/domains/heap_domain.cpp
+++ b/src/domains/heap_domain.cpp
@@ -13,6 +13,7 @@ Author: Viktor Malik
 #include <algorithm>
 #include <memory>
 #include <ssa/address_canonizer.h>
+#include <util/mathematical_types.h>
 
 /// Initialize abstract value. Clears value with empty value rows corresponding
 /// to template.

--- a/src/domains/incremental_solver.cpp
+++ b/src/domains/incremental_solver.cpp
@@ -29,22 +29,9 @@ void incremental_solvert::new_context()
 #endif
 
 #else
-
-  literalt activation_literal=
-    solver->convert(
-      symbol_exprt(
-        "goto_symex::\\act$"+
-        std::to_string(activation_literal_counter++), bool_typet()));
-
+  solver->push();
 #ifdef DEBUG_OUTPUT
-    debug() << "new context: " << activation_literal<< eom;
-#endif
-
-  activation_literals.push_back(activation_literal);
-  solver->set_assumptions(activation_literals);
-
-#if 0
-  return !activation_literals.back(); // not to be used anymore
+    debug() << "new context" <<  eom;
 #endif
 #endif
 }
@@ -62,45 +49,10 @@ void incremental_solvert::pop_context()
 
 #else
 
-  assert(!activation_literals.empty());
-  literalt activation_literal=activation_literals.back();
-  activation_literals.pop_back();
-#ifndef DEBUG_FORMULA
-  solver->set_to_false(literal_exprt(activation_literal));
-#else
-  formula.push_back(!activation_literal);
-#endif
-
+  solver->pop();
 #ifdef DEBUG_OUTPUT
-    debug() << "pop context: " << activation_literal << eom;
+    debug() << "pop context" << eom;
 #endif
-
-  solver->set_assumptions(activation_literals);
-#endif
-}
-
-void incremental_solvert::make_context_permanent()
-{
-#ifdef NON_INCREMENTAL
-  assert(contexts.size()>=2);
-  contextst::iterator c_it=contexts.end(); c_it--; c_it--;
-  c_it->insert(c_it->end(), contexts.back().begin(), contexts.back().end());
-  contexts.pop_back();
-#else
-  assert(!activation_literals.empty());
-  literalt activation_literal=activation_literals.back();
-  activation_literals.pop_back();
-#ifndef DEBUG_FORMULA
-  solver->set_to_true(literal_exprt(activation_literal));
-#else
-  formula.push_back(activation_literal);
-#endif
-
-#ifdef DEBUG_OUTPUT
-    debug() << "make context permanent: " << activation_literal<< eom;
-#endif
-
-  solver->set_assumptions(activation_literals);
 #endif
 }
 

--- a/src/domains/lexlinrank_domain.cpp
+++ b/src/domains/lexlinrank_domain.cpp
@@ -43,7 +43,7 @@ void lexlinrank_domaint::initialize_value(domaint::valuet &value)
 void lexlinrank_domaint::initialize()
 {
   delete inner_solver;
-  inner_solver=incremental_solvert::allocate(ns);
+  inner_solver=incremental_solvert::allocate(ns, message_handler);
 }
 
 bool lexlinrank_domaint::edit_row(const rowt &row, valuet &inv, bool improved)
@@ -133,7 +133,7 @@ bool lexlinrank_domaint::edit_row(const rowt &row, valuet &inv, bool improved)
       {
         number_elements_per_row[row]++;
         delete inner_solver;
-        inner_solver=incremental_solvert::allocate(ns);
+        inner_solver=incremental_solvert::allocate(ns, message_handler);
         reset_refinements();
 
         rank[row].add_element();

--- a/src/domains/lexlinrank_domain.h
+++ b/src/domains/lexlinrank_domain.h
@@ -102,14 +102,16 @@ public:
     replace_mapt &_renaming_map,
     unsigned _max_elements, // lexicographic components
     unsigned _max_inner_iterations,
-    const namespacet &_ns):
+    const namespacet &_ns,
+    message_handlert &_message_handler):
     simple_domaint(_domain_number, _renaming_map, _ns),
     refinement_level(0),
     max_elements(_max_elements),
     max_inner_iterations(_max_inner_iterations),
-    number_inner_iterations(0)
+    number_inner_iterations(0),
+    message_handler(_message_handler)
   {
-    inner_solver=incremental_solvert::allocate(_ns);
+    inner_solver=incremental_solvert::allocate(_ns, _message_handler);
   }
 
 
@@ -162,6 +164,7 @@ public:
   const unsigned max_inner_iterations;
   incremental_solvert *inner_solver;
   unsigned number_inner_iterations;
+  message_handlert &message_handler;
 
   std::vector<unsigned> number_elements_per_row;
 };

--- a/src/domains/linrank_domain.h
+++ b/src/domains/linrank_domain.h
@@ -79,14 +79,16 @@ public:
     replace_mapt &_renaming_map,
     unsigned _max_elements, // lexicographic components
     unsigned _max_inner_iterations,
-    const namespacet &_ns):
+    const namespacet &_ns,
+    message_handlert &_message_handler):
     simple_domaint(_domain_number, _renaming_map, _ns),
     refinement_level(0),
     max_elements(_max_elements),
     max_inner_iterations(_max_inner_iterations),
-    number_inner_iterations(0)
+    number_inner_iterations(0),
+    message_handler(_message_handler)
   {
-    inner_solver=incremental_solvert::allocate(_ns);
+    inner_solver=incremental_solvert::allocate(_ns, _message_handler);
   }
 
   // initialize value
@@ -132,6 +134,7 @@ public:
   const unsigned max_inner_iterations;
   incremental_solvert *inner_solver;
   unsigned number_inner_iterations;
+  message_handlert &message_handler;
 };
 
 #endif // CPROVER_2LS_DOMAINS_LINRANK_DOMAIN_H

--- a/src/domains/predabs_domain.cpp
+++ b/src/domains/predabs_domain.cpp
@@ -30,7 +30,7 @@ void predabs_domaint::initialize_value(domaint::valuet &value)
   for(std::size_t row=0; row<templ.size(); ++row)
   {
     // start from top (we can only use a gfp solver for this domain)
-    v[row]=false_exprt();
+    v[row]=row_valuet();
   }
 }
 

--- a/src/domains/predabs_domain.h
+++ b/src/domains/predabs_domain.h
@@ -33,13 +33,18 @@ public:
     void output(std::ostream &out, const namespacet &ns) const override;
   };
 
-  typedef constant_exprt row_valuet;
+  struct row_valuet:constant_exprt
+  {
+    row_valuet() : constant_exprt(false_exprt()) {}
+
+    explicit row_valuet(const constant_exprt &value) : constant_exprt(value) {}
+  };
 
   struct templ_valuet:simple_domaint::valuet, std::vector<row_valuet>
   {
     void set_row_value(rowt row, const constant_exprt &value)
     {
-      (*this)[row]=value;
+      (*this)[row]=row_valuet(value);
     }
 
     exprt get_row_expr(rowt row, const template_rowt &templ_row) const override

--- a/src/domains/strategy_solver_binsearch2.cpp
+++ b/src/domains/strategy_solver_binsearch2.cpp
@@ -91,10 +91,12 @@ bool strategy_solver_binsearch2t::iterate(invariantt &_inv)
         debug() << "improve row " << row  << eom;
 #endif
         improve_rows.insert(row);
-        symb_values[row]=tpolyhedra_domain.get_row_symb_value(row);
-        lower_values[row]=
+        symb_values.insert({row, tpolyhedra_domain.get_row_symb_value(row)});
+        lower_values.insert({
+          row,
           simplify_const(
-            solver.get(tpolyhedra_domain.strategy_value_exprs[row][0]));
+            solver.get(
+              tpolyhedra_domain.strategy_value_exprs[row][0]))});
         blocking_constraint.push_back(
           literal_exprt(!tpolyhedra_domain.strategy_cond_literals[row]));
         if(inv[row].is_neg_inf())
@@ -122,12 +124,12 @@ bool strategy_solver_binsearch2t::iterate(invariantt &_inv)
   assert(lower_values.size()>=1);
   std::map<tpolyhedra_domaint::rowt, symbol_exprt>::iterator
     it=symb_values.begin();
-  exprt _lower=lower_values[it->first];
+  exprt _lower=lower_values.at(it->first);
 #if 1
   debug() << "update row " << it->first << ": "
-          << from_expr(SSA.ns, "", lower_values[it->first]) << eom;
+          << from_expr(SSA.ns, "", lower_values.at(it->first)) << eom;
 #endif
-  inv[it->first]=lower_values[it->first];
+  inv[it->first]=lower_values.at(it->first);
   exprt _upper=
     tpolyhedra_domain.get_max_row_value(it->first);
   exprt sum=it->second;
@@ -135,13 +137,13 @@ bool strategy_solver_binsearch2t::iterate(invariantt &_inv)
   {
     sum=plus_exprt(sum, it->second);
     _upper=plus_exprt(_upper, tpolyhedra_domain.get_max_row_value(it->first));
-    _lower=plus_exprt(_lower, lower_values[it->first]);
+    _lower=plus_exprt(_lower, lower_values.at(it->first));
 
 #if 1
     debug() << "update row " << it->first << ": "
-            << from_expr(SSA.ns, "", lower_values[it->first]) << eom;
+            << from_expr(SSA.ns, "", lower_values.at(it->first)) << eom;
 #endif
-    inv[it->first]=lower_values[it->first];
+    inv[it->first]=lower_values.at(it->first);
   }
 
   // do not solve system if we have just reached a new loop

--- a/src/domains/strategy_solver_binsearch3.cpp
+++ b/src/domains/strategy_solver_binsearch3.cpp
@@ -86,10 +86,12 @@ bool strategy_solver_binsearch3t::iterate(invariantt &_inv)
         debug() << "improve row " << row  << eom;
 #endif
         improve_rows.insert(row);
-        symb_values[row]=tpolyhedra_domain.get_row_symb_value(row);
-        lower_values[row]=
+        symb_values.insert({row, tpolyhedra_domain.get_row_symb_value(row)});
+        lower_values.insert({
+          row,
           simplify_const(
-            solver.get(tpolyhedra_domain.strategy_value_exprs[row][0]));
+            solver.get(
+              tpolyhedra_domain.strategy_value_exprs[row][0]))});
         blocking_constraint.push_back(
           literal_exprt(!tpolyhedra_domain.strategy_cond_literals[row]));
         if(inv[row].is_neg_inf())
@@ -117,12 +119,12 @@ bool strategy_solver_binsearch3t::iterate(invariantt &_inv)
   assert(lower_values.size()>=1);
   std::map<tpolyhedra_domaint::rowt, symbol_exprt>::iterator
     it=symb_values.begin();
-  exprt _lower=lower_values[it->first];
+  exprt _lower=lower_values.at(it->first);
 #if 1
   debug() << "update row " << it->first << ": "
-          << from_expr(SSA.ns, "", lower_values[it->first]) << eom;
+          << from_expr(SSA.ns, "", lower_values.at(it->first)) << eom;
 #endif
-  inv[it->first]=lower_values[it->first];
+  inv[it->first]=lower_values.at(it->first);
   exprt _upper=
     tpolyhedra_domain.get_max_row_value(it->first);
   exprt sum=it->second;
@@ -130,13 +132,13 @@ bool strategy_solver_binsearch3t::iterate(invariantt &_inv)
   {
     sum=plus_exprt(sum, it->second);
     _upper=plus_exprt(_upper, tpolyhedra_domain.get_max_row_value(it->first));
-    _lower=plus_exprt(_lower, lower_values[it->first]);
+    _lower=plus_exprt(_lower, lower_values.at(it->first));
 
 #if 1
     debug() << "update row " << it->first << ": "
-            << from_expr(SSA.ns, "", lower_values[it->first]) << eom;
+            << from_expr(SSA.ns, "", lower_values.at(it->first)) << eom;
 #endif
-    inv[it->first]=lower_values[it->first];
+    inv[it->first]=lower_values.at(it->first);
   }
 
   // do not solve system if we have just reached a new loop

--- a/src/domains/template_generator_base.h
+++ b/src/domains/template_generator_base.h
@@ -116,11 +116,10 @@ protected:
     local_SSAt::nodest::const_iterator n_it,
     exprt &pre_guard,
     exprt &post_guard);
-  void get_pre_var(
+  symbol_exprt get_pre_var(
     const local_SSAt &SSA,
     local_SSAt::objectst::const_iterator o_it,
-    local_SSAt::nodest::const_iterator n_it,
-    symbol_exprt &pre_var);
+    local_SSAt::nodest::const_iterator n_it);
 
   void get_init_expr(
     const local_SSAt &SSA,

--- a/src/domains/template_generator_callingcontext.cpp
+++ b/src/domains/template_generator_callingcontext.cpp
@@ -71,8 +71,8 @@ void template_generator_callingcontextt::collect_variables_callingcontext(
   for(local_SSAt::var_sett::iterator v_it=cs_globals_in.begin();
       v_it!=cs_globals_in.end(); v_it++)
   {
-    symbol_exprt dummy;
-    if(ssa_inlinert::find_corresponding_symbol(*v_it, globals_in, dummy) ||
+    auto dummy=ssa_inlinert::find_corresponding_symbol(*v_it, globals_in);
+    if(dummy ||
        id2string(v_it->get_identifier()).find("dynamic_object$")!=
        std::string::npos)
     {

--- a/src/domains/template_generator_ranking.cpp
+++ b/src/domains/template_generator_ranking.cpp
@@ -38,7 +38,8 @@ void template_generator_rankingt::operator()(
         post_renaming_map,
         options.get_unsigned_int_option("lexicographic-ranking-function"),
         options.get_unsigned_int_option("max-inner-ranking-iterations"),
-        SSA.ns));
+        SSA.ns,
+        get_message_handler()));
   }
   else
   {
@@ -48,7 +49,8 @@ void template_generator_rankingt::operator()(
         post_renaming_map,
         options.get_unsigned_int_option("lexicographic-ranking-function"),
         options.get_unsigned_int_option("max-inner-ranking-iterations"),
-        SSA.ns));
+        SSA.ns,
+        get_message_handler()));
   }
   collect_variables_ranking(SSA, forward);
 

--- a/src/domains/template_generator_summary.cpp
+++ b/src/domains/template_generator_summary.cpp
@@ -36,8 +36,7 @@ void template_generator_summaryt::operator()(
   collect_variables_loop(SSA, forward);
 
   // do not compute summary for entry-point
-  if(SSA.goto_function.body.instructions.front().function!=
-     goto_functionst::entry_point() ||
+  if(SSA.function_identifier!=goto_functionst::entry_point() ||
      options.get_bool_option("preconditions"))
     collect_variables_inout(SSA, forward);
 

--- a/src/domains/tpolyhedra_domain.h
+++ b/src/domains/tpolyhedra_domain.h
@@ -37,7 +37,7 @@ public:
   /// Row value (parameter) is a constant
   struct row_valuet:constant_exprt
   {
-    row_valuet()=default;
+    row_valuet(): constant_exprt(false_exprt()) {}
     explicit row_valuet(const constant_exprt &value) : constant_exprt(value) {}
     using constant_exprt::operator=;
 

--- a/src/domains/util.cpp
+++ b/src/domains/util.cpp
@@ -190,7 +190,7 @@ mp_integer simplify_const_int(const exprt &expr)
   if(expr.id()==ID_constant)
   {
     mp_integer v;
-    to_integer(expr, v);
+    to_integer(to_constant_expr(expr), v);
     return v;
   }
   if(expr.id()==ID_typecast)
@@ -227,7 +227,7 @@ mp_integer simplify_const_int(const exprt &expr)
     if(array_type.id()==ID_signedbv || array_type.id()==ID_unsignedbv)
     {
       mp_integer mp_index=simplify_const_int(index_expr.index());
-      unsigned index=integer2unsigned(mp_index); // TODO: might overflow
+      auto index=numeric_cast_v<unsigned>(mp_index); // TODO: might overflow
       assert(index<(index_expr.array().operands().size()));
       return simplify_const_int(index_expr.array().operands()[index]);
     }
@@ -308,7 +308,7 @@ ieee_floatt simplify_const_float(const exprt &expr)
     if(array_type.id()==ID_float)
     {
       mp_integer mp_index=simplify_const_int(index_expr.index());
-      unsigned index=integer2unsigned(mp_index); // TODO: might overflow
+      auto index=numeric_cast_v<unsigned>(mp_index); // TODO: might overflow
       assert(index<(index_expr.array().operands().size()));
       return simplify_const_float(index_expr.array().operands()[index]);
     }

--- a/src/solver/summarizer_fw_contexts.cpp
+++ b/src/solver/summarizer_fw_contexts.cpp
@@ -18,7 +18,8 @@ Author: Peter Schrammel
 #include <util/find_symbols.h>
 
 #include <util/xml.h>
-#include <util/xml_expr.h>
+#include <util/xml_irep.h>
+#include <goto-programs/xml_expr.h>
 
 #include "summarizer_fw_contexts.h"
 #include "summary_db.h"

--- a/src/solver/summarizer_fw_contexts.h
+++ b/src/solver/summarizer_fw_contexts.h
@@ -14,7 +14,7 @@ Author: Peter Schrammel
 
 #include <util/message.h>
 #include <util/options.h>
-#include <langapi/language_ui.h>
+#include <util/ui_message.h>
 
 #include <ssa/ssa_inliner.h>
 #include <ssa/ssa_unwinder.h>
@@ -48,7 +48,7 @@ public:
   virtual void summarize();
 
  protected:
-  language_uit::uit ui; // use gui format
+  ui_message_handlert::uit ui; // use gui format
   std::set<irep_idt> excluded_functions;
 
   virtual void inline_summaries(

--- a/src/ssa/dynobj_instance_analysis.cpp
+++ b/src/ssa/dynobj_instance_analysis.cpp
@@ -262,3 +262,11 @@ void dynobj_instance_domaint::output(
     out << "\n";
   }
 }
+
+void dynobj_instance_analysist::initialize(
+  const irep_idt &function_id,
+  const goto_programt &goto_program)
+{
+  forall_goto_program_instructions(i_it, goto_program)
+    get_state(i_it).make_bottom();
+}

--- a/src/ssa/dynobj_instance_analysis.h
+++ b/src/ssa/dynobj_instance_analysis.h
@@ -144,6 +144,8 @@ protected:
 class dynobj_instance_domaint:public ai_domain_baset
 {
 public:
+  dynobj_instance_domaint(): has_values(false) {}
+
   // Must-alias relation for each dynamic object (corresponding to allocation
   // site).
   std::map<symbol_exprt, must_alias_setst> must_alias_relations;
@@ -224,6 +226,9 @@ public:
 protected:
   const optionst &options;
   ssa_value_ait &value_analysis;
+  void initialize(
+    const irep_idt &function_id,
+    const goto_programt &goto_program) override;
 
   friend class dynobj_instance_domaint;
 };

--- a/src/ssa/local_ssa.cpp
+++ b/src/ssa/local_ssa.cpp
@@ -18,8 +18,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/prefix.h>
 #include <util/expr_util.h>
-#include <util/decision_procedure.h>
 #include <util/byte_operators.h>
+#include <solvers/decision_procedure.h>
 
 #include <goto-programs/adjust_float_expressions.h>
 
@@ -83,7 +83,7 @@ void local_SSAt::get_entry_exit_vars()
   // get globals out (includes return value)
   goto_programt::const_targett
     last=goto_function.body.instructions.end(); last--;
-  get_globals(last, globals_out, true, true, last->function);
+  get_globals(last, globals_out, true, true, function_identifier);
 }
 
 void local_SSAt::get_globals(

--- a/src/ssa/may_alias_analysis.cpp
+++ b/src/ssa/may_alias_analysis.cpp
@@ -119,3 +119,12 @@ void may_alias_domaint::members_to_symbols(exprt &expr, const namespacet &ns)
     expr=object.symbol_expr();
   Forall_operands(it, expr)members_to_symbols(*it, ns);
 }
+
+void may_alias_analysist::initialize(
+  const irep_idt &function_id,
+  const goto_functionst::goto_functiont &goto_function)
+{
+  ait<may_alias_domaint>::initialize(function_id, goto_function);
+  forall_goto_program_instructions(i_it, goto_function.body)
+    get_state(i_it).make_bottom();
+}

--- a/src/ssa/may_alias_analysis.h
+++ b/src/ssa/may_alias_analysis.h
@@ -20,6 +20,8 @@ Author: Viktor Malik, imalik@fit.vutbr.cz
 class may_alias_domaint:public ai_domain_baset
 {
 public:
+  may_alias_domaint(): has_values(false) {}
+
   void transform(
     const irep_idt &,
     locationt from,
@@ -81,6 +83,10 @@ public:
   {
     operator()(function_identifier, goto_function, ns);
   }
+protected:
+  void initialize(
+    const irep_idt &function_id,
+    const goto_functionst::goto_functiont &goto_function) override;
 };
 
 

--- a/src/ssa/ssa_build_goto_trace.cpp
+++ b/src/ssa/ssa_build_goto_trace.cpp
@@ -64,6 +64,8 @@ bool ssa_build_goto_tracet::can_convert_ssa_expr(const exprt &expr)
     can_convert_ssa_expr(index.array());
 
     mp_integer idx;
+    if(!index.index().is_constant())
+      return false;
     if(to_integer(to_constant_expr(index.index()), idx))
       return false;
     return true;
@@ -166,9 +168,6 @@ bool ssa_build_goto_tracet::record_step(
 
   case ASSIGN:
   {
-    if(has_prefix(id2string(current_pc->function), CPROVER_PREFIX))
-      break;
-
     const code_assignt &code_assign=
       to_code_assign(current_pc->code);
 
@@ -178,6 +177,8 @@ bool ssa_build_goto_tracet::record_step(
     exprt rhs_simplified=simplify_expr(rhs_value, unwindable_local_SSA.ns);
     exprt lhs_ssa=finalize_lhs(code_assign.lhs());
     exprt lhs_simplified=simplify_expr(lhs_ssa, unwindable_local_SSA.ns);
+    if(from_expr(lhs_simplified).find(CPROVER_PREFIX)!=std::string::npos)
+      break;
 
 #if 0
     std::cout << "ASSIGN "
@@ -221,7 +222,7 @@ bool ssa_build_goto_tracet::record_step(
       break;
 
     // skip undetermined rhs
-    find_symbols_sett rhs_symbols;
+    std::set<symbol_exprt> rhs_symbols;
     find_symbols(rhs_simplified, rhs_symbols);
     if(!rhs_symbols.empty() || rhs_simplified.id()==ID_nondet_symbol)
       break;

--- a/src/ssa/ssa_db.h
+++ b/src/ssa/ssa_db.h
@@ -18,7 +18,7 @@ Author: Peter Schrammel
 #include <domains/incremental_solver.h>
 #include <goto-programs/goto_functions.h>
 
-class ssa_dbt
+class ssa_dbt:public messaget
 {
 public:
   typedef irep_idt function_namet;
@@ -52,6 +52,7 @@ public:
     the_solvers[function_name]=
       incremental_solvert::allocate(
         store.at(function_name)->ns,
+        get_message_handler(),
         options.get_bool_option("refine"));
     return *the_solvers.at(function_name);
   }

--- a/src/ssa/ssa_dereference.cpp
+++ b/src/ssa/ssa_dereference.cpp
@@ -254,11 +254,9 @@ exprt ssa_alias_value(
     }
   }
 
-  byte_extract_exprt byte_extract(byte_extract_id(), e1.type());
   if(competition_mode)
     assert(!e2_type.get_bool("#dynamic"));
-  byte_extract.op()=e2;
-  byte_extract.offset()=offset1;
+  byte_extract_exprt byte_extract(byte_extract_id(), e2, offset1, e1.type());
 
   return byte_extract;
 }

--- a/src/ssa/ssa_domain.cpp
+++ b/src/ssa/ssa_domain.cpp
@@ -229,16 +229,21 @@ ssa_domaint::def_mapt::const_iterator ssa_domaint::get_object_allocation_def(
   return def_map.end();
 }
 
-void ssa_ait::initialize(const goto_functionst::goto_functiont &goto_function)
+void ssa_ait::initialize(
+  const irep_idt &function_id,
+  const goto_functionst::goto_functiont &goto_function)
 {
-  ait<ssa_domaint>::initialize(goto_function);
+  ait<ssa_domaint>::initialize(function_id, goto_function);
+  forall_goto_program_instructions(i_it, goto_function.body)
+    get_state(i_it).make_bottom();
 
   // Make entry instruction have a source for the all objects.
 
   if(!goto_function.body.instructions.empty())
   {
     locationt e=goto_function.body.instructions.begin();
-    ssa_domaint &entry=operator[](e);
+    auto entry_s=entry_state(goto_function.body);
+    ssa_domaint &entry=dynamic_cast<ssa_domaint &>(get_state(entry_s));
 
     #if 0
     // parameters

--- a/src/ssa/ssa_domain.h
+++ b/src/ssa/ssa_domain.h
@@ -20,6 +20,8 @@ Author: Daniel Kroening, kroening@kroening.com
 class ssa_domaint:public ai_domain_baset
 {
 public:
+  ssa_domaint(): has_values(false) {}
+
   // sources for identifiers
   struct deft
   {
@@ -145,7 +147,9 @@ protected:
 
   // The overload below is needed to make the entry point get a source
   // for all objects.
-  virtual void initialize(const goto_functionst::goto_functiont &goto_function);
+  void initialize(
+    const irep_idt &function_id,
+    const goto_functionst::goto_functiont &goto_function) override;
 };
 
 #endif

--- a/src/ssa/ssa_inliner.h
+++ b/src/ssa/ssa_inliner.h
@@ -69,12 +69,6 @@ public:
     const local_SSAt::var_sett &cs_globals_out, // outgoing globals at call site
     const local_SSAt &function);
 
-  void replace(
-    local_SSAt &SSA,
-    const ssa_dbt &ssa_db,
-    bool recursive=false,
-    bool rename=true);
-
   void havoc(
     local_SSAt::nodet &node,
     local_SSAt::nodet::function_callst::iterator f_it);
@@ -99,10 +93,9 @@ public:
     const local_SSAt::var_sett &globals_in,
     exprt &expr);
 
-  static bool find_corresponding_symbol(
+  static optionalt<symbol_exprt> find_corresponding_symbol(
     const symbol_exprt &s,
-    const local_SSAt::var_sett &globals,
-    symbol_exprt &s_found);
+    const local_SSAt::var_sett &globals);
 
   static irep_idt get_original_identifier(const symbol_exprt &s);
 

--- a/src/ssa/ssa_object.cpp
+++ b/src/ssa/ssa_object.cpp
@@ -52,7 +52,7 @@ void collect_ptr_objects(
       const symbolt *symbol;
       if(dynamic ||
          (!ns.lookup(src.get_identifier(), symbol) &&
-          !symbol->is_procedure_local()))
+          symbol->is_static_lifetime))
         ptr_object.type().set("#dynamic", true);
 
       if(is_ptr_object(src))
@@ -240,7 +240,7 @@ void ssa_objectst::categorize_objects(
       else
       {
         const symbolt &symbol=ns.lookup(to_symbol_expr(root_object));
-        if(symbol.is_procedure_local())
+        if(!symbol.is_static_lifetime)
         {
           if(dirty(symbol.name))
             dirty_locals.insert(*o_it);

--- a/src/ssa/ssa_pointed_objects.cpp
+++ b/src/ssa/ssa_pointed_objects.cpp
@@ -96,7 +96,7 @@ symbol_exprt pointed_object(const exprt &expr, const namespacet &ns)
     {
       pointed.set(
         level_str(level, ID_pointer_subtype),
-        to_symbol_type(pointed_type).get_identifier());
+        to_struct_tag_type(pointed_type).get_identifier());
     }
 
     return pointed;
@@ -108,7 +108,7 @@ symbol_exprt pointed_object(const exprt &expr, const namespacet &ns)
 const irep_idt pointer_root_id(const exprt &expr)
 {
   assert(expr.get_bool(ID_pointed));
-  unsigned max_level_index=expr.get_unsigned_int(ID_pointed_level)-1;
+  unsigned max_level_index=expr.get_size_t(ID_pointed_level)-1;
   if(expr.get(level_str(max_level_index, ID_pointer_id))==ID_symbol)
     return expr.get(level_str(max_level_index, ID_pointer_sym));
   else
@@ -118,7 +118,7 @@ const irep_idt pointer_root_id(const exprt &expr)
 unsigned pointed_level(const exprt &expr)
 {
   if(is_pointed(expr))
-    return expr.get_unsigned_int(ID_pointed_level);
+    return expr.get_size_t(ID_pointed_level);
   else
     return 0;
 }
@@ -134,7 +134,7 @@ const exprt get_pointer(const exprt &expr, unsigned level)
   exprt pointer;
 
   const typet &pointed_type=
-    symbol_typet(expr.get(level_str(level, ID_pointer_subtype)));
+    struct_tag_typet(expr.get(level_str(level, ID_pointer_subtype)));
 
   if(expr.get(level_str(level, ID_pointer_id))==ID_symbol)
   {

--- a/src/ssa/ssa_unwinder.cpp
+++ b/src/ssa/ssa_unwinder.cpp
@@ -118,7 +118,7 @@ void ssa_local_unwindert::build_pre_post_map()
 
       it->second.modified_vars.push_back(o_it->get_expr());
       symbol_exprt pre=SSA.name(*o_it, local_SSAt::PHI, pre_loc);
-      it->second.pre_post_map[pre]=SSA.read_rhs(*o_it, post_loc);
+      it->second.pre_post_map.insert({pre, SSA.read_rhs(*o_it, post_loc)});
     }
   }
 }
@@ -447,7 +447,7 @@ void ssa_local_unwindert::add_loop_connector(loopt &loop)
     {
       node.equalities.push_back(*e_it);
       node.equalities.back().rhs()=
-        loop.pre_post_map[to_symbol_expr(e_it->lhs())];
+        loop.pre_post_map.at(to_symbol_expr(e_it->lhs()));
       SSA.rename(node.equalities.back().rhs(), node.location);
       SSA.decrement_unwindings(0);
       SSA.rename(node.equalities.back().lhs(), node.location);

--- a/src/ssa/ssa_unwinder.h
+++ b/src/ssa/ssa_unwinder.h
@@ -29,7 +29,8 @@ public:
     fname(_fname),
     SSA(_SSA),
     is_kinduction(_is_kinduction),
-    is_bmc(_is_bmc)
+    is_bmc(_is_bmc),
+    current_enabling_expr(bool_typet())
   {
   }
 

--- a/src/ssa/ssa_value_set.h
+++ b/src/ssa/ssa_value_set.h
@@ -21,6 +21,8 @@ Author: Daniel Kroening, kroening@kroening.com
 class ssa_value_domaint:public ai_domain_baset
 {
 public:
+  ssa_value_domaint(): has_values(false) {}
+
   void transform(
     const irep_idt &,
     locationt,
@@ -100,7 +102,7 @@ public:
   typedef std::map<ssa_objectt, valuest> value_mapt;
   value_mapt value_map;
 
-  bool competition_mode;
+  bool competition_mode=false;
 
   const valuest operator()(
     const exprt &src,
@@ -164,7 +166,8 @@ public:
   }
 
 protected:
-  virtual void initialize(
+  void initialize(
+    const irep_idt &function_id,
     const goto_functionst::goto_functiont &goto_function) override;
 
   void assign_ptr_param(const exprt &expr, ssa_value_domaint &entry);

--- a/src/ssa/ssa_var_collector.h
+++ b/src/ssa/ssa_var_collector.h
@@ -53,11 +53,10 @@ public:
     exprt &pre_guard,
     exprt &post_guard);
 
-  void get_pre_var(
+  symbol_exprt get_pre_var(
     const local_SSAt &SSA,
     local_SSAt::objectst::const_iterator o_it,
-    local_SSAt::nodest::const_iterator n_it,
-    symbol_exprt &pre_var);
+    local_SSAt::nodest::const_iterator n_it);
 
   void get_init_expr(
     const local_SSAt &SSA,


### PR DESCRIPTION
There have been a lot of changes in this pull request. Below is just a short overview of the most significant ones and some comments:
 - Vast abstract interpretation changes, usually required adding explicit initialization to bottom. I was also a bit struggling with constant propagator throwing `failed to find state error` but it turned out I had to call it a bit differently to make it initialize states.
 - Function identifier was removed from goto instruction ( https://github.com/diffblue/cbmc/pull/3126 ) which caused some problems. I usually ended up using the indentifier stored in SSA and passing it around. One case where it behaves slightly differently is inlining (previously the original function was kept even during inlining). This caused issue in trying to ignore __CPROVER_initialize function (mainly the variables assigned in it), we ended up checking for the CPROVER prefix in the variables rather than looking at the functions.
 - Removed property checker (https://github.com/diffblue/2ls/commit/5b05f182b8cd1068d2225f4ccfe95e44160c4cc9) required a lot of changes. We also noticed that new assertion status was added (previously it was unknown - ok - fail, now there is also not checked). We ended up sticking with `UNKNOWN` for now (for compatibility) but this may be a place for potential refactoring (differentiating between not having checked the property and having checked it but not knowing its correctness).
 - Significant solver changes - we ended up using the contexts provided by CBMC rather than the previous implementation. This seems to have also sped up the calculations which is great!
 - And a lot of other small API and call changes, too many to list them all
 - We agreed with @viktormalik to temporarily disable one test ( https://github.com/diffblue/2ls/commit/80deaffc84781171c6e253f35325d10c8ccaa8cc). I've been trying to find the issue in it for hours, however no luck yet and I'd rather get this going again and fix this one small issue (along with true memsafety tests that we disabled some time ago) once it's all done. The formulae pushed to the solver seem to be the same but in the new version it throws UNSAT, whereas in the old it resulted in SAT. Such issues are almost impossible to debug since the solver is basically a black box.

Looking at the CI failures, I will push one more commit with code style fixes (will squash it at the end). I don't really know why compilation with `clang++3.7` is failing but it seems to come from CBMC so probably not much I can do about that...

Related: https://github.com/peterschrammel/cbmc/pull/25