### PR TITLE
Support linting even from the master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         run: ./build.sh $COMPILER -j4 && cd regression && make test
   lint:
     runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2
       - name: Get the latest master


### PR DESCRIPTION
The action would fail after a pull request is merged into master due to the `git fetch` command which refuses to fetch the current branch.