### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/2ls/2ls_parse_options.cpp
+++ b/src/2ls/2ls_parse_options.cpp
@@ -700,6 +700,7 @@ int twols_parse_optionst::doit()
       report_unknown();
       break;
 
+    case resultt::ERROR:
     default:
       assert(false);
     }
@@ -855,6 +856,21 @@ void twols_parse_optionst::show_stats(
         type_stats_rec(instruction.decl_symbol().type(), stats, ns);
         break;
 
+      case NO_INSTRUCTION_TYPE:
+      case OTHER:
+      case SKIP:
+      case START_THREAD:
+      case END_THREAD:
+      case LOCATION:
+      case END_FUNCTION:
+      case ATOMIC_BEGIN:
+      case ATOMIC_END:
+      case SET_RETURN_VALUE:
+      case DEAD:
+      case FUNCTION_CALL:
+      case THROW:
+      case CATCH:
+      case INCOMPLETE_GOTO:
       default:
         // skip
         break;
@@ -950,7 +966,7 @@ bool twols_parse_optionst::get_goto_program(
     return true;
   }
 
-  catch(std::bad_alloc)
+  catch(std::bad_alloc&)
   {
     error() << "Out of memory" << eom;
     return true;
@@ -1183,7 +1199,7 @@ bool twols_parse_optionst::process_goto_program(
     return true;
   }
 
-  catch(std::bad_alloc)
+  catch(std::bad_alloc&)
   {
     error() << "Out of memory" << eom;
     return true;
@@ -1278,6 +1294,7 @@ void twols_parse_optionst::report_success()
   switch(ui_message_handler.get_ui())
   {
   case ui_message_handlert::uit::PLAIN:
+  case ui_message_handlert::uit::JSON_UI:
     break;
 
   case ui_message_handlert::uit::XML_UI:
@@ -1315,6 +1332,7 @@ void twols_parse_optionst::show_counterexample(
   }
   break;
 
+  case ui_message_handlert::uit::JSON_UI:
   default:
     assert(false);
   }
@@ -1402,6 +1420,7 @@ void twols_parse_optionst::report_failure()
   switch(ui_message_handler.get_ui())
   {
   case ui_message_handlert::uit::PLAIN:
+  case ui_message_handlert::uit::JSON_UI:
     break;
 
   case ui_message_handlert::uit::XML_UI:
@@ -1425,6 +1444,7 @@ void twols_parse_optionst::report_unknown()
   switch(ui_message_handler.get_ui())
   {
   case ui_message_handlert::uit::PLAIN:
+  case ui_message_handlert::uit::JSON_UI:
     break;
 
   case ui_message_handlert::uit::XML_UI:

--- a/src/2ls/cover_goals_ext.cpp
+++ b/src/2ls/cover_goals_ext.cpp
@@ -98,6 +98,7 @@ void cover_goals_extt::operator()()
         return; // exit on first failure if requested
       break;
 
+    case decision_proceduret::resultt::D_ERROR:
     default:
       error() << "decision procedure has failed" << eom;
       return;

--- a/src/2ls/preprocessing_util.cpp
+++ b/src/2ls/preprocessing_util.cpp
@@ -88,7 +88,7 @@ void twols_parse_optionst::nondet_locals(goto_modelt &goto_model)
         side_effect_expr_nondett nondet(
           decl.symbol().type(),
           i_it->source_location);
-        goto_programt::targett t=f_it.second.body.insert_after(
+        f_it.second.body.insert_after(
           i_it,
           goto_programt::make_assignment(
             code_assignt(decl.symbol(), nondet),
@@ -391,10 +391,9 @@ void twols_parse_optionst::remove_loops_in_entry(goto_modelt &goto_model)
        f_it.second.body.instructions.begin()->is_target())
     {
       auto insert_before=f_it.second.body.instructions.begin();
-      auto new_entry=
-        f_it.second.body.insert_before(
-          insert_before,
-          goto_programt::make_skip(insert_before->source_location));
+      f_it.second.body.insert_before(
+        insert_before,
+        goto_programt::make_skip(insert_before->source_location));
     }
   }
 }

--- a/src/2ls/summary_checker_nonterm.cpp
+++ b/src/2ls/summary_checker_nonterm.cpp
@@ -399,6 +399,7 @@ void summary_checker_nontermt::check_properties_linear(
           solver.pop_context();
         break;
 
+      case decision_proceduret::resultt::D_ERROR:
       default:
         error() << "decision procedure has failed" << eom;
         solver.pop_context();
@@ -418,6 +419,7 @@ void summary_checker_nontermt::check_properties_linear(
           solver.pop_context();
         continue;
 
+      case decision_proceduret::resultt::D_ERROR:
       default:
         error() << "decision procedure has failed" << eom;
         solver.pop_context();
@@ -460,6 +462,7 @@ void summary_checker_nontermt::check_properties_linear(
           solver.pop_context();
         break;
 
+      case decision_proceduret::resultt::D_ERROR:
       default:
         error() << "decision procedure has failed" << eom;
         solver.pop_context();
@@ -539,6 +542,7 @@ void summary_checker_nontermt::check_properties_linear(
             solver << not_exprt(conjunction(local_constraints));
           break;
 
+        case decision_proceduret::resultt::D_ERROR:
         default:
           error() << "decision procedure has failed" << eom;
           solver.pop_context();
@@ -567,6 +571,7 @@ void summary_checker_nontermt::check_properties_linear(
           solver.pop_context();
         return;
 
+      case decision_proceduret::resultt::D_ERROR:
       default:
         error() << "decision procedure has failed" << eom;
         solver.pop_context();

--- a/src/config.inc
+++ b/src/config.inc
@@ -1,7 +1,13 @@
 CPROVER_DIR = ../../lib/cbmc
 
 # Variables you may want to override
-#CXXFLAGS = -Wall -O0 -g -Werror -Wno-long-long -Wno-sign-compare -Wno-parentheses -Wno-strict-aliasing -pedantic
+
+# Enable warnings
+CXXFLAGS += -Wall -Werror -Wno-long-long -Wno-sign-compare -Wno-parentheses -Wno-strict-aliasing -pedantic
+
+# Select optimisation or debug
+#CXXFLAGS += -O2
+#CXXFLAGS += -O0 -g
 
 #static compilation
 #LINKFLAGS += -static-libgcc -static-libstdc++

--- a/src/domains/heap_domain.cpp
+++ b/src/domains/heap_domain.cpp
@@ -44,7 +44,6 @@ void heap_domaint::make_template(
     const vart &var=v.var;
     if(var.type().id()==ID_pointer)
     {
-      const typet &pointed_type=ns.follow(var.type().subtype());
       add_template_row({var}, v.guards);
 
       if(var.id()==ID_symbol &&

--- a/src/domains/heap_domain.cpp
+++ b/src/domains/heap_domain.cpp
@@ -249,7 +249,7 @@ const exprt heap_domaint::get_points_to_dest(
     }
 
     // Add equality p == &obj
-    return obj;
+    return std::move(obj);
   }
   else
     return nil_exprt();

--- a/src/domains/product_domain.cpp
+++ b/src/domains/product_domain.cpp
@@ -91,7 +91,7 @@ std::unique_ptr<strategy_solver_baset> product_domaint::new_strategy_solver(
   solver_vect solvers;
   for(auto &d : domains)
     solvers.push_back(
-      std::move(d->new_strategy_solver(solver, SSA, message_handler)));
+      d->new_strategy_solver(solver, SSA, message_handler));
   return std::unique_ptr<strategy_solver_baset>(
     new strategy_solver_productt(
       *this, std::move(solvers), solver, SSA, message_handler));

--- a/src/domains/product_domain.h
+++ b/src/domains/product_domain.h
@@ -52,7 +52,7 @@ public:
   {
     value_vect values;
     for(auto &d : domains)
-      values.push_back(std::move(d->new_value()));
+      values.push_back(d->new_value());
     return std::unique_ptr<valuet>(new valuet(std::move(values)));
   }
 

--- a/src/domains/simple_domain.h
+++ b/src/domains/simple_domain.h
@@ -33,6 +33,7 @@ public:
   /// Template row expression - defined per-domain
   struct template_row_exprt
   {
+    virtual ~template_row_exprt()=default;
     /// Get a vector of expressions used in the row
     virtual std::vector<exprt> get_row_exprs()=0;
     /// Output the template row (with the template row parameters)

--- a/src/domains/strategy_solver_binsearch3.h
+++ b/src/domains/strategy_solver_binsearch3.h
@@ -25,7 +25,7 @@ class strategy_solver_binsearch3t:public strategy_solver_baset
     incremental_solvert &_solver,
     const local_SSAt& _SSA,
     message_handlert &message_handler):
-    strategy_solver_baset(_solver, SSA, message_handler),
+    strategy_solver_baset(_solver, _SSA, message_handler),
     tpolyhedra_domain(_tpolyhedra_domain),
     sum_bound_counter(0) {}
 

--- a/src/domains/tpolyhedra_domain.cpp
+++ b/src/domains/tpolyhedra_domain.cpp
@@ -469,7 +469,7 @@ void tpolyhedra_domaint::add_quadratic_template(
   unsigned size=2*var_specs.size();
   templ.reserve(templ.size()+size);
 
-  for(const auto v : var_specs)
+  for(const auto &v : var_specs)
   {
     if(v.guards.kind==guardst::IN)
       continue;
@@ -525,15 +525,16 @@ std::unique_ptr<strategy_solver_baset> tpolyhedra_domaint::new_strategy_solver(
   {
   case ENUMERATION:
     return simple_domaint::new_strategy_solver(solver, SSA, message_handler);
-  case BINSEARCH:
-    return std::unique_ptr<strategy_solver_baset>(
-      new strategy_solver_binsearcht(*this, solver, SSA, message_handler));
   case BINSEARCH2:
     return std::unique_ptr<strategy_solver_baset>(
       new strategy_solver_binsearch2t(*this, solver, SSA, message_handler));
   case BINSEARCH3:
     return std::unique_ptr<strategy_solver_baset>(
       new strategy_solver_binsearch3t(*this, solver, SSA, message_handler));
+  case BINSEARCH:
+  default: // Default to binsearch if value is invalid
+    return std::unique_ptr<strategy_solver_baset>(
+      new strategy_solver_binsearcht(*this, solver, SSA, message_handler));
   }
 }
 

--- a/src/solver/summarizer_base.cpp
+++ b/src/solver/summarizer_base.cpp
@@ -121,6 +121,7 @@ bool summarizer_baset::check_call_reachable(
     debug() << "Call is not reachable" << eom;
     break;
   }
+  case decision_proceduret::resultt::D_ERROR:
   default: assert(false); break;
   }
 
@@ -313,6 +314,7 @@ bool summarizer_baset::check_precondition(
 
     break;
   }
+  case decision_proceduret::resultt::D_ERROR:
   default: assert(false); break;
   }
 

--- a/src/solver/summarizer_bw.cpp
+++ b/src/solver/summarizer_bw.cpp
@@ -364,6 +364,7 @@ bool summarizer_bwt::check_postcondition(
 
     break;
   }
+  case decision_proceduret::resultt::D_ERROR:
   default: assert(false); break;
   }
 

--- a/src/solver/summarizer_fw_contexts.cpp
+++ b/src/solver/summarizer_fw_contexts.cpp
@@ -79,6 +79,7 @@ void summarizer_fw_contextst::inline_summaries(
         switch(ui)
         {
         case ui_message_handlert::uit::PLAIN:
+        case ui_message_handlert::uit::JSON_UI:
           break;
 
         case ui_message_handlert::uit::XML_UI:

--- a/src/ssa/address_canonizer.cpp
+++ b/src/ssa/address_canonizer.cpp
@@ -85,22 +85,22 @@ exprt address_canonizer(
     if(ns.follow(tmp.op0().type()).id()==ID_pointer)
     {
       tmp.op0()=address_canonizer(tmp.op0(), ns);
-      return tmp;
+      return std::move(tmp);
     }
     else if(ns.follow(tmp.op1().type()).id()==ID_pointer)
     {
       tmp.op1()=address_canonizer(tmp.op1(), ns);
-      return tmp;
+      return std::move(tmp);
     }
     else
-      return tmp;
+      return std::move(tmp);
   }
   else if(address.id()==ID_if)
   {
     if_exprt tmp=to_if_expr(address);
     tmp.true_case()=address_canonizer(tmp.true_case(), ns);
     tmp.false_case()=address_canonizer(tmp.false_case(), ns);
-    return tmp;
+    return std::move(tmp);
   }
   else if(address.id()==ID_typecast)
   {
@@ -110,7 +110,7 @@ exprt address_canonizer(
     if(tmp.op().type().id()==ID_pointer)
     {
       tmp.op()=address_canonizer(tmp.op(), ns);
-      return tmp;
+      return std::move(tmp);
     }
 
     return address;

--- a/src/ssa/address_canonizer.cpp
+++ b/src/ssa/address_canonizer.cpp
@@ -115,6 +115,5 @@ exprt address_canonizer(
 
     return address;
   }
-  else
-    return address;
+  return address;
 }

--- a/src/ssa/local_ssa.cpp
+++ b/src/ssa/local_ssa.cpp
@@ -783,20 +783,20 @@ exprt local_SSAt::read_rhs_address_of_rec(
     // We 'read' the pointer only, the dereferencing expression stays.
     dereference_exprt tmp=to_dereference_expr(expr);
     tmp.pointer()=read_rhs_rec(tmp.pointer(), loc);
-    return tmp;
+    return std::move(tmp);
   }
   else if(expr.id()==ID_member)
   {
     member_exprt tmp=to_member_expr(expr);
     tmp.struct_op()=read_rhs_address_of_rec(tmp.struct_op(), loc);
-    return tmp;
+    return std::move(tmp);
   }
   else if(expr.id()==ID_index)
   {
     index_exprt tmp=to_index_expr(expr);
     tmp.array()=read_rhs_address_of_rec(tmp.array(), loc);
     tmp.index()=read_rhs_rec(tmp.index(), loc);
-    return tmp;
+    return std::move(tmp);
   }
   else if(expr.id()==ID_if)
   {
@@ -804,7 +804,7 @@ exprt local_SSAt::read_rhs_address_of_rec(
     tmp.cond()=read_rhs_rec(tmp.cond(), loc);
     tmp.true_case()=read_rhs_address_of_rec(tmp.true_case(), loc);
     tmp.false_case()=read_rhs_address_of_rec(tmp.false_case(), loc);
-    return tmp;
+    return std::move(tmp);
   }
   else
     return expr;

--- a/src/ssa/ssa_build_goto_trace.cpp
+++ b/src/ssa/ssa_build_goto_trace.cpp
@@ -249,6 +249,7 @@ bool ssa_build_goto_tracet::record_step(
     break;
 
   case NO_INSTRUCTION_TYPE:
+  case INCOMPLETE_GOTO:
     assert(false);
     break;
   }

--- a/src/ssa/ssa_build_goto_trace.cpp
+++ b/src/ssa/ssa_build_goto_trace.cpp
@@ -29,7 +29,7 @@ exprt ssa_build_goto_tracet::finalize_lhs(const exprt &src)
     tmp.array()=finalize_lhs(tmp.array());
     exprt index=unwindable_local_SSA.read_rhs(tmp.index(), current_pc);
     tmp.index()=simplify_expr(prop_conv.get(index), unwindable_local_SSA.ns);
-    return tmp;
+    return std::move(tmp);
   }
   else if(src.id()==ID_dereference)
   {
@@ -48,7 +48,7 @@ exprt ssa_build_goto_tracet::finalize_lhs(const exprt &src)
   {
     member_exprt tmp=to_member_expr(src);
     tmp.struct_op()=finalize_lhs(tmp.struct_op());
-    return tmp;
+    return std::move(tmp);
   }
   else
     return src;

--- a/src/ssa/ssa_dereference.cpp
+++ b/src/ssa/ssa_dereference.cpp
@@ -232,7 +232,7 @@ exprt ssa_alias_value(
     assert(!e2_type.get_bool("#dynamic"));
   byte_extract_exprt byte_extract=make_byte_extract(e2, offset1, e1.type());
 
-  return byte_extract;
+  return std::move(byte_extract);
 }
 
 exprt dereference_rec(
@@ -316,7 +316,7 @@ exprt dereference_rec(
       return result;
     }
     else
-      return tmp;
+      return std::move(tmp);
   }
   else if(src.id()==ID_address_of)
   {
@@ -335,7 +335,7 @@ exprt dereference_rec(
       return result;
     }
     else
-      return tmp;
+      return std::move(tmp);
   }
   else
   {

--- a/src/ssa/ssa_domain.h
+++ b/src/ssa/ssa_domain.h
@@ -88,7 +88,7 @@ public:
   virtual void output(
     std::ostream &out,
     const ai_baset &ai,
-    const namespacet &ns) const;
+    const namespacet &ns) const override;
 
   bool merge(
     const ssa_domaint &b,

--- a/src/ssa/ssa_inliner.cpp
+++ b/src/ssa/ssa_inliner.cpp
@@ -936,7 +936,7 @@ exprt ssa_inlinert::param_in_transformer(const exprt &param)
   assert(param.id()==ID_symbol);
   symbol_exprt param_in=to_symbol_expr(param);
   rename(param_in);
-  return param_in;
+  return std::move(param_in);
 }
 
 exprt ssa_inlinert::arg_in_transformer(
@@ -956,7 +956,7 @@ exprt ssa_inlinert::param_in_member_transformer(
     id2string(to_symbol_expr(param).get_identifier())+"."+
     id2string(component.get_name()), component.type());
   rename(param_member);
-  return param_member;
+  return std::move(param_member);
 }
 
 exprt ssa_inlinert::arg_in_member_transformer(
@@ -983,7 +983,7 @@ exprt ssa_inlinert::param_out_transformer(
   {
     address_of_exprt param_addr=address_of_exprt(param);
     rename(param_addr);
-    return param_addr;
+    return std::move(param_addr);
   }
   else
   {
@@ -996,7 +996,7 @@ exprt ssa_inlinert::param_out_transformer(
       param_out=*maybe_new;
       rename(param_out);
     }
-    return param_out;
+    return std::move(param_out);
   }
 }
 
@@ -1021,7 +1021,7 @@ exprt ssa_inlinert::arg_out_transformer(
     }
 
     covered_cs_heap_out.insert(arg_symbol);
-    return arg_addr;
+    return std::move(arg_addr);
   }
   else
   {

--- a/src/ssa/ssa_pointed_objects.cpp
+++ b/src/ssa/ssa_pointed_objects.cpp
@@ -181,7 +181,7 @@ const exprt symbolic_dereference(const exprt &expr, const namespacet &ns)
 
     symbol_exprt sym_deref=pointed_object(pointer_object.symbol_expr(), ns);
     sym_deref.set("#has_symbolic_deref", true);
-    return sym_deref;
+    return std::move(sym_deref);
   }
   else if(expr.id()==ID_member)
   {
@@ -193,7 +193,7 @@ const exprt symbolic_dereference(const exprt &expr, const namespacet &ns)
       "#has_symbolic_deref",
       has_symbolic_deref(member.compound()));
 
-    return member;
+    return std::move(member);
   }
   else
   {

--- a/src/ssa/ssa_value_set.cpp
+++ b/src/ssa/ssa_value_set.cpp
@@ -66,8 +66,6 @@ void ssa_value_domaint::transform(
     const irep_idt &fname=to_symbol_expr(
       code_function_call.function()).get_identifier();
 
-    const ssa_value_ait &value_analysis=static_cast<ssa_value_ait &>(ai);
-
     // functions may alter state almost arbitrarily:
     // * any global-scoped variables
     // * any dirty locals

--- a/src/ssa/unwindable_local_ssa.h
+++ b/src/ssa/unwindable_local_ssa.h
@@ -41,7 +41,7 @@ public:
   virtual symbol_exprt name(
     const ssa_objectt &obj,
     kindt kind,
-    locationt loc) const
+    locationt loc) const override
   {
     return name(obj, kind, loc, loc);
   }
@@ -54,7 +54,7 @@ public:
     std::string prefix,
     const typet &type,
     locationt loc,
-    unsigned counter) const;
+    unsigned counter) const override;
 
   // control renaming during unwindings
   typedef std::vector<unsigned> odometert;


### PR DESCRIPTION
This PR fixed warnings thrown by gcc and clang and also makes `config.inc` a bit more modular similar to how CBMC does this. Also `-Werror` is now enabled by default.