### PR TITLE
SV-COMP fixes

### DIFF
--- a/regression/kiki/hard2_unwindbound5/main.c
+++ b/regression/kiki/hard2_unwindbound5/main.c
@@ -1,0 +1,61 @@
+/*
+  hardware integer division program, by Manna
+  returns q==A//B
+  */
+
+extern void abort(void);
+extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "hard2.c", 8, "reach_error"); }
+extern int __VERIFIER_nondet_int(void);
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        {reach_error();}
+    }
+    return;
+}
+
+int counter = 0;
+int main() {
+    int A, B;
+    int r, d, p, q;
+    A = __VERIFIER_nondet_int();
+    B = 1;
+
+    r = A;
+    d = B;
+    p = 1;
+    q = 0;
+
+    while (counter++<5) {
+        __VERIFIER_assert(q == 0);
+        __VERIFIER_assert(r == A);
+        __VERIFIER_assert(d == B * p);
+        if (!(r >= d)) break;
+
+        d = 2 * d;
+        p = 2 * p;
+    }
+
+    while (counter++<5) {
+        __VERIFIER_assert(A == q*B + r);
+        __VERIFIER_assert(d == B*p);
+
+        if (!(p != 1)) break;
+
+        d = d / 2;
+        p = p / 2;
+        if (r >= d) {
+            r = r - d;
+            q = q + p;
+        }
+    }
+
+    __VERIFIER_assert(A == d*q + r);
+    __VERIFIER_assert(B == d);
+    return 0;
+}

--- a/regression/kiki/hard2_unwindbound5/test.desc
+++ b/regression/kiki/hard2_unwindbound5/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--heap --values-refine --k-induction --competition-mode
+^EXIT=10$
+^SIGNAL=0$
+^.*FAILURE$
+--
+--
+This is a past incorrect true benchmark from SV-comp which was caused by a bug
+in SSA unwinder where the generated constraints made the analysis unsound.

--- a/regression/memsafety/built_from_end/test.desc
+++ b/regression/memsafety/built_from_end/test.desc
@@ -1,35 +1,6 @@
-KNOWNBUG
+CORE
 main.c
 --heap --intervals --pointer-check --no-assertions
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
---
---
-CBMC 5.9 introduced changes to its implementation of some built-in functions,
-the ones affecting this test are malloc and free. Malloc changes have been
-already accounted for in 2LS codebase, however the control flow of free
-is most likely causing problems in this test making one of the asserts fail:
-
-[main.pointer_dereference.27] dereference failure: deallocated dynamic object in *p: UNKNOWN
-
-This may be related to double free assertion, where GOTO changed from:
-
-...
-    IF !(__CPROVER_deallocated == ptr) THEN GOTO 6
-    // 144 file <builtin-library-free> line 18 function free
-    ASSERT 0 != 0 // double free
-    // 145 no location
-    ASSUME 0 != 0
-    // 146 file <builtin-library-free> line 29 function free
- 6: _Bool record;
-...
-
-to:
-    ASSERT ptr == NULL || __CPROVER_deallocated != ptr // double free
-
-Note the new ptr == NULL condition, this could be the root cause of
-the problem. However further investigation is required
-and will be done once the CBMC rebase is completed. According to the
-C standard, free(NULL) is a valid construct (no operation) but 2LS doesn't
-seem to handle this case correctly.

--- a/regression/memsafety/double_free/main.c
+++ b/regression/memsafety/double_free/main.c
@@ -1,0 +1,9 @@
+void *my_malloc(unsigned int size) {
+    return malloc(size);
+}
+
+int main() {
+    void *a = my_malloc(sizeof(int));
+    free(a);
+    free(a);
+}

--- a/regression/memsafety/double_free/test.desc
+++ b/regression/memsafety/double_free/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--pointer-check --inline
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+\[free.precondition.6\] free argument must be NULL or valid pointer: FAILURE

--- a/regression/memsafety/simple_true/test.desc
+++ b/regression/memsafety/simple_true/test.desc
@@ -1,36 +1,6 @@
-KNOWNBUG
+CORE
 main.c
 --heap --intervals --pointer-check --no-assertions
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
---
---
-CBMC 5.9 introduced changes to its implementation of some built-in functions,
-the ones affecting this test are malloc and free. Malloc changes have been
-already accounted for in 2LS codebase, however the control flow of free
-is most likely causing problems in this test making one of the asserts fail:
-
-[main.pointer_dereference.27] dereference failure: deallocated dynamic object in *p: UNKNOWN
-
-This may be related to double free assertion, where GOTO changed from:
-
-...
-    IF !(__CPROVER_deallocated == ptr) THEN GOTO 6
-    // 144 file <builtin-library-free> line 18 function free
-    ASSERT 0 != 0 // double free
-    // 145 no location
-    ASSUME 0 != 0
-    // 146 file <builtin-library-free> line 29 function free
- 6: _Bool record;
-...
-
-to:
-    ASSERT ptr == NULL || __CPROVER_deallocated != ptr // double free
-
-Note the new ptr == NULL condition, this could be the root cause of
-the problem. However further investigation is required
-and will be done once the CBMC rebase is completed. According to the
-C standard, free(NULL) is a valid construct (no operation) but 2LS doesn't
-seem to handle this case correctly.
-

--- a/regression/preconditions/precond_contextsensitive1/test.desc
+++ b/regression/preconditions/precond_contextsensitive1/test.desc
@@ -3,4 +3,4 @@ main.c
 --context-sensitive --preconditions
 ^EXIT=5$
 ^SIGNAL=0$
-^\[sign\]: sign#return_value#phi20 <= 0 && -\(\(signed __CPROVER_bitvector\[33\]\)sign#return_value#phi20\) <= 0 ==> x <= 0 && -\(\(signed __CPROVER_bitvector\[33\]\)x\) <= 0$
+^\[sign\]: sign#return_value#phi21 <= 0 && -\(\(signed __CPROVER_bitvector\[33\]\)sign#return_value#phi21\) <= 0 ==> x <= 0 && -\(\(signed __CPROVER_bitvector\[33\]\)x\) <= 0$

--- a/src/2ls/2ls_parse_options.cpp
+++ b/src/2ls/2ls_parse_options.cpp
@@ -22,6 +22,7 @@ Author: Daniel Kroening, Peter Schrammel
 
 #include <ansi-c/ansi_c_language.h>
 #include <ansi-c/cprover_library.h>
+#include <ansi-c/gcc_version.h>
 #include <cpp/cpp_language.h>
 
 #include <goto-programs/goto_convert_functions.h>
@@ -395,6 +396,14 @@ int twols_parse_optionst::doit()
   status() << "2LS version " TWOLS_VERSION << eom;
 
   register_languages();
+
+  // configure gcc, if required
+  if(config.ansi_c.preprocessor == configt::ansi_ct::preprocessort::GCC)
+  {
+    gcc_versiont gcc_version;
+    gcc_version.get("gcc");
+    configure_gcc(gcc_version);
+  }
 
   if(get_goto_program(options))
     return 6;

--- a/src/2ls/2ls_parse_options.cpp
+++ b/src/2ls/2ls_parse_options.cpp
@@ -1141,6 +1141,12 @@ bool twols_parse_optionst::process_goto_program(
 
     remove_dead_goto(goto_model);
 
+    // There's a bug in SSA creation that causes problems when a single SKIP
+    // instruction is a target of both a forward and a backward GOTO.
+    // This transformation fixes that by splitting such SKIPs into two.
+    // TODO: fix this properly in SSA, if possible.
+    fix_goto_targets(goto_model);
+
     if(cmdline.isset("competition-mode"))
     {
       limit_array_bounds(goto_model);

--- a/src/2ls/2ls_parse_options.h
+++ b/src/2ls/2ls_parse_options.h
@@ -197,6 +197,7 @@ protected:
   void handle_freed_ptr_compare(goto_modelt &goto_model);
   void assert_no_builtin_functions(goto_modelt &goto_model);
   void assert_no_atexit(goto_modelt &goto_model);
+  void fix_goto_targets(goto_modelt &goto_model);
 };
 
 #endif

--- a/src/2ls/preprocessing_util.cpp
+++ b/src/2ls/preprocessing_util.cpp
@@ -674,7 +674,7 @@ void twols_parse_optionst::limit_array_bounds(goto_modelt &goto_model)
           if(size_expr.id()==ID_constant)
           {
             int size=std::stoi(
-              id2string(to_constant_expr(size_expr).get_value()), nullptr, 2);
+              id2string(to_constant_expr(size_expr).get_value()), nullptr, 16);
             // @TODO temporary solution - there seems to be a bug in the solver
             assert(size<=50000);
           }

--- a/src/ssa/dynobj_instance_analysis.cpp
+++ b/src/ssa/dynobj_instance_analysis.cpp
@@ -213,6 +213,7 @@ bool dynobj_instance_domaint::merge(
   trace_ptrt trace_to)
 {
   bool result=has_values.is_false() && !other.has_values.is_false();
+  has_values=tvt::unknown();
   for(auto &obj : other.must_alias_relations)
   {
     if(must_alias_relations.find(obj.first)==must_alias_relations.end())

--- a/src/ssa/local_ssa.cpp
+++ b/src/ssa/local_ssa.cpp
@@ -1541,10 +1541,10 @@ void local_SSAt::collect_allocation_guards(
 
 void local_SSAt::collect_record_frees(local_SSAt::locationt loc)
 {
-  if(loc->is_decl())
+  if(loc->is_assign())
   {
-    const code_declt &code_decl=code_declt{loc->decl_symbol()};
-    const exprt &symbol=code_decl.symbol();
+    const code_assignt &code_assign=to_code_assign(loc->get_code());
+    const exprt &symbol=code_assign.lhs();
     if(symbol.id()!=ID_symbol)
       return;
 

--- a/src/ssa/local_ssa.cpp
+++ b/src/ssa/local_ssa.cpp
@@ -1110,40 +1110,8 @@ void local_SSAt::assign_rec(
   {
     const if_exprt &if_expr=to_if_expr(lhs);
 
-    exprt::operandst other_cond_conj;
-    if(if_expr.true_case().get_bool("#heap_access") &&
-       if_expr.cond().id()==ID_equal)
-    {
-      const exprt heap_object=if_expr.true_case();
-      const ssa_objectt ptr_object(to_equal_expr(if_expr.cond()).lhs(), ns);
-      if(ptr_object)
-      {
-        const irep_idt ptr_id=ptr_object.get_identifier();
-        const exprt cond=read_rhs(if_expr.cond(), loc);
-
-        for(const dyn_obj_assignt &do_assign : dyn_obj_assigns[heap_object])
-        {
-          if(!alias_analysis[loc].aliases.same_set(
-            ptr_id, do_assign.pointer_id))
-          {
-            other_cond_conj.push_back(do_assign.cond);
-          }
-        }
-
-        dyn_obj_assigns[heap_object].emplace_back(ptr_id, cond);
-      }
-    }
-
-    exprt cond=if_expr.cond();
-    if(!other_cond_conj.empty())
-    {
-      const exprt other_cond=or_exprt(
-        not_exprt(conjunction(other_cond_conj)),
-        name(guard_symbol(), OBJECT_SELECT, loc));
-      cond=and_exprt(cond, other_cond);
-    }
     exprt orig_rhs=fresh_rhs ? name(ssa_objectt(rhs, ns), OUT, loc) : rhs;
-    exprt new_rhs=if_exprt(cond, orig_rhs, if_expr.true_case());
+    exprt new_rhs=if_exprt(if_expr.cond(), orig_rhs, if_expr.true_case());
     assign_rec(
       if_expr.true_case(),
       new_rhs,

--- a/src/ssa/local_ssa.cpp
+++ b/src/ssa/local_ssa.cpp
@@ -51,6 +51,9 @@ void local_SSAt::build_SSA()
     build_function_call(i_it);
 //    build_unknown_objs(i_it);
     collect_record_frees(i_it);
+
+    if (options.get_bool_option("competition-mode"))
+      disable_unsupported_instructions(i_it);
   }
 
   // collect custom templates in loop heads
@@ -1643,4 +1646,14 @@ bool local_SSAt::can_reuse_symderef(
   }
 
   return true;
+}
+
+void local_SSAt::disable_unsupported_instructions(locationt loc)
+{
+  if (loc->is_other())
+  {
+    auto st = loc->get_code().get_statement();
+    if(st=="array_copy" || st=="array_replace")
+      assert(false);
+  }
 }

--- a/src/ssa/local_ssa.h
+++ b/src/ssa/local_ssa.h
@@ -279,6 +279,10 @@ protected:
   void collect_custom_templates();
   replace_mapt template_newvars;
   exprt template_last_newvar;
+
+  optionalt<ssa_domaint::deft> get_recent_object_alloc_def(
+    locationt loc,
+    const ssa_domaint::def_mapt::const_iterator &def) const;
 };
 
 std::list<exprt> & operator <<

--- a/src/ssa/local_ssa.h
+++ b/src/ssa/local_ssa.h
@@ -51,7 +51,6 @@ public:
       options,
       ssa_objects,
       ssa_value_ai),
-    alias_analysis(_function_identifier, _goto_function, ns),
     guard_map(_goto_function.body),
     function_identifier(_function_identifier),
     ssa_analysis(assignments),
@@ -148,20 +147,6 @@ public:
   // unknown heap objects
   var_sett unknown_objs;
 
-  // Maps members of dynamic object to a set of pointers used to access those
-  // objects when assigning them
-  class dyn_obj_assignt
-  {
-  public:
-    const irep_idt pointer_id;
-    const exprt cond;
-
-    dyn_obj_assignt(const irep_idt &pointer_id, const exprt &cond):
-      pointer_id(pointer_id), cond(cond) {}
-  };
-  typedef std::list<dyn_obj_assignt> dyn_obj_assignst;
-  std::map<exprt, dyn_obj_assignst> dyn_obj_assigns;
-
   // Map dynamic object names to guards of their allocation
   std::map<irep_idt, exprt> allocation_guards;
 
@@ -238,8 +223,6 @@ public:
   typedef ssa_objectst::objectst objectst;
   ssa_value_ait ssa_value_ai;
   assignmentst assignments;
-
-  may_alias_analysist alias_analysis;
 
 // protected:
   guard_mapt guard_map;

--- a/src/ssa/local_ssa.h
+++ b/src/ssa/local_ssa.h
@@ -271,6 +271,9 @@ protected:
   void build_assertions(locationt loc);
   void build_unknown_objs(locationt loc);
 
+  // competition-mode specific checks
+  void disable_unsupported_instructions(locationt loc);
+
   void collect_allocation_guards(const code_assignt &assign, locationt loc);
   void get_alloc_guard_rec(const exprt &expr, exprt old_guard);
   void collect_record_frees(locationt loc);

--- a/src/ssa/malloc_ssa.cpp
+++ b/src/ssa/malloc_ssa.cpp
@@ -72,6 +72,8 @@ exprt create_dynamic_object(
       from_integer(0, index_type()),
       value_symbol.type.subtype());
     object=index_expr;
+    if(is_concrete)
+      to_index_expr(object).array().set("#concrete", true);
   }
   else
   {

--- a/src/ssa/ssa_domain.h
+++ b/src/ssa/ssa_domain.h
@@ -34,6 +34,7 @@ public:
     inline bool is_input() const { return kind==INPUT; }
     inline bool is_assignment() const { return kind==ASSIGNMENT; }
     inline bool is_phi() const { return kind==PHI; }
+    inline bool is_allocation() const { return kind==ALLOCATION; }
   };
 
   friend inline bool operator==(const deft &a, const deft &b)

--- a/src/ssa/ssa_unwinder.cpp
+++ b/src/ssa/ssa_unwinder.cpp
@@ -529,7 +529,7 @@ void ssa_local_unwindert::add_hoisted_assertions(loopt &loop, bool is_last)
             to_not_expr(it->first->guard).op().id()==ID_overflow_shl))
 #endif
     {
-      exprt e=disjunction(it->second.exit_conditions);
+      exprt e=conjunction(it->second.exit_conditions);
       SSA.rename(e, loop.body_nodes.begin()->location);
       SSA.nodes.push_back(
         local_SSAt::nodet(it->first, SSA.nodes.end())); // add new node


### PR DESCRIPTION
This implements fixes for problems mostly created during the recent CBMC rebase that were revealed in SV-COMP runs.

These are in particular:
- Fix of `dynobj_instance_analysis` which caused that dynamic objects were never split into multiple instances. This, however, broke heap regression tests.
- Fix usage of allocation guards w.r.t. new `malloc` implementation in CBMC that makes the regression tests work again.
- Fix collection of `record::free` vars w.r.t. new `free` implementation.
- Drop conditional update of dynamic objects which caused some false positive results (due to over-approximation) and which shouldn't be necessary since we use dynamic object instances (that should guarantee soundness).
- Improve resolution of pointed-to objects obtained from the solver in heap domain.
- Workaround for an SSA creation bug that occurs when a single SKIP instruction is a target of both a forward and a backward GOTO.
- ... and some more (see individual commits)

Besides that, CBMC prerequisite is updated to the newest version (may require rebase once peterschrammel/cbmc#27 is merged).