### PR TITLE
Unwind using GOTO unwinder

### DIFF
--- a/regression/heap-data/calendar_false/main.c
+++ b/regression/heap-data/calendar_false/main.c
@@ -1,0 +1,40 @@
+extern int __VERIFIER_nondet_int();
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+#include <stdlib.h>
+
+#define APPEND(l,i) {i->next=l; l=i;}
+
+typedef struct node {
+    struct node *next;
+    int event1;
+    int event2;
+} Node;
+
+int main() {
+    Node *l = NULL;
+ 
+    while (__VERIFIER_nondet_int()) {
+        int ev1 = __VERIFIER_nondet_int();
+        int ev2 = __VERIFIER_nondet_int();
+        if (ev1 < 0 || ev1 > 3 || ev2 < 0 || ev2 > 3)
+            continue;
+        
+        if (((ev1 == 0) && (ev2 == 2)) || ((ev1 == 0) && (ev2 == 3)))
+            continue;
+
+        Node *p = malloc(sizeof(*p));
+        p->event1 = ev1;
+        p->event2 = ev2;
+        APPEND(l,p)
+    }
+
+    Node *i = l;
+
+    while (i != NULL) {
+        if (((i->event1 == 1) && (i->event2 == 3)) || ((i->event1 == 0) && (i->event2 == 2)))
+            __VERIFIER_error();
+        i = i->next;
+    }
+}
+

--- a/regression/heap-data/calendar_false/test.desc
+++ b/regression/heap-data/calendar_false/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--heap --values-refine --k-induction
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$

--- a/regression/heap-data/min_max_false/main.c
+++ b/regression/heap-data/min_max_false/main.c
@@ -1,0 +1,40 @@
+extern int __VERIFIER_nondet_int();
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+#include <stdlib.h>
+#include <limits.h>
+
+#define APPEND(l,i) {i->next=l; l=i;}
+
+typedef struct node {
+    struct node *next;
+    int val;
+} Node;
+
+int main() {
+    Node *l = NULL;
+    int min = INT_MAX, max = -INT_MAX;
+ 
+    while (__VERIFIER_nondet_int()) {
+        Node *p = malloc(sizeof(*p));
+        p->val = __VERIFIER_nondet_int();
+        APPEND(l, p)
+        
+        if (min < p->val) {
+            min = p->val;
+        }
+        if (max > p->val) {
+            max = p->val;
+        }
+
+    }
+
+    Node *i = l;
+    while (i != NULL) {
+        if (i->val < min)
+            __VERIFIER_error();
+        if (i->val > max)
+            __VERIFIER_error();
+        i = i->next;
+    }
+}

--- a/regression/heap-data/min_max_false/test.desc
+++ b/regression/heap-data/min_max_false/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--heap --values-refine --k-induction
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$

--- a/regression/heap-data/packet_filter_false/main.c
+++ b/regression/heap-data/packet_filter_false/main.c
@@ -1,0 +1,87 @@
+extern unsigned __VERIFIER_nondet_uint();
+extern int __VERIFIER_nondet_int();
+extern char *__VERIFIER_nondet_charp();
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+#include <stdlib.h>
+
+#define LOW 0
+#define HIGH 1
+
+typedef struct packet {
+    unsigned size;
+    unsigned prio;
+    unsigned index;
+    char *payload;
+} Packet;
+
+typedef struct packet_list_node {
+    struct packet packet;
+    struct packet_list_node *next;
+} *Node;
+
+struct packet_queue {
+    struct packet_list_node *front;
+};
+
+
+Packet receive() {
+    Packet packet;
+    static unsigned index = 0;
+    index++;
+    packet.size = __VERIFIER_nondet_uint();
+    packet.prio = __VERIFIER_nondet_int() ? LOW : HIGH;
+    packet.payload = __VERIFIER_nondet_charp();
+    packet.index = index;
+    return packet;
+}
+
+extern void send(struct packet p);
+
+void append_to_queue(Packet p, Node *q) {
+    Node node = malloc(sizeof(*node));
+    node->packet = p;
+    node->next = *q;
+    *q = node;
+}
+
+void process_prio_queue(Node q) {
+    for (Node node = q; node != NULL; node = node->next) {
+        if (!(node->packet.prio == HIGH || node->packet.size < 500))
+            __VERIFIER_error();
+        send(node->packet);
+    }
+}
+
+void process_normal_queue(Node q) {
+    for (Node node = q; node != NULL; node = node->next) {
+        if (!(node->packet.prio == LOW && node->packet.size >= 500))
+            __VERIFIER_error();
+        send(node->packet);
+    }
+}
+
+int main() {
+    Node prio_queue = NULL;
+    Node normal_queue = NULL;
+
+    while (__VERIFIER_nondet_int()) {
+        Packet new_packet = receive();
+        if (new_packet.size > 0) {
+            if (new_packet.index > 4) {
+              append_to_queue(new_packet, &prio_queue);
+            } else if (new_packet.prio == HIGH) {
+                append_to_queue(new_packet, &prio_queue);
+            } else if (new_packet.size < 500) {
+                append_to_queue(new_packet, &prio_queue);
+            } else {
+                append_to_queue(new_packet, &normal_queue);
+            }
+        }
+    }
+    
+    process_prio_queue(prio_queue);
+    process_normal_queue(normal_queue);
+
+    return 0;
+}

--- a/regression/heap-data/packet_filter_false/test.desc
+++ b/regression/heap-data/packet_filter_false/test.desc
@@ -1,0 +1,6 @@
+THOROUGH
+main.c
+--heap --values-refine --k-induction
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$

--- a/regression/heap-data/running_example_assume/test.desc
+++ b/regression/heap-data/running_example_assume/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --heap --values-refine
 ^EXIT=0$

--- a/regression/heap-data/running_example_false/main.c
+++ b/regression/heap-data/running_example_false/main.c
@@ -1,0 +1,35 @@
+extern int __VERIFIER_nondet_int();
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+#include <stdlib.h>
+
+typedef struct node {
+    int val;
+    struct node *next;
+} Node;
+
+int main() {
+    Node *p, *list = malloc(sizeof(*list));
+    Node *tail = list;
+    list->next = NULL;
+    list->val = 10;
+    while (__VERIFIER_nondet_int()) {
+        int x;
+        if (x < 10 || x > 20) continue;
+        p = malloc(sizeof(*p));
+        tail->next = p;
+        p->next = NULL;
+        p->val = x;
+        tail = p;
+    }
+
+    while (1) {
+        for (p = list; p!= NULL; p = p->next) {
+            if (!(p->val <= 20 && p->val >= 10))
+                __VERIFIER_error();
+            if (p->val < 20) p->val--;
+            else p->val /= 2;
+        }
+    }
+}
+

--- a/regression/heap-data/running_example_false/test.desc
+++ b/regression/heap-data/running_example_false/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--heap --values-refine --k-induction
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$

--- a/regression/heap-data/shared_mem1_false/main.c
+++ b/regression/heap-data/shared_mem1_false/main.c
@@ -1,0 +1,51 @@
+extern int __VERIFIER_nondet_int();
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+#include <stdlib.h>
+
+struct mem {
+    int val;
+};
+
+struct list_node {
+    int x;
+    struct mem *mem;
+    struct list_node *next;
+};
+
+int main() {
+    struct mem *m = malloc(sizeof(*m));
+    m->val = 100;
+
+    struct list_node *head = malloc(sizeof(*head));
+    head->x = 1;
+    head->mem = m;
+    head->next = head;
+
+    struct list_node *list = head;
+
+    int i = 0;
+    while (__VERIFIER_nondet_int()) {
+        int x = __VERIFIER_nondet_int();
+        if (x > 0 && x < 10) {
+            struct list_node *n = malloc(sizeof(*n));
+            n->x = x+i;
+            n->mem = m;
+            n->next = head;
+            list->next = n;
+            i++;
+        }
+    }
+
+    list = head;
+    while (list) {
+        if (list->mem->val <= 100)
+            list->mem->val += list->x;
+        else
+            list->mem->val -= list->x;
+        list = list->next;
+
+        if (!(m->val > 90 && m->val < 110))
+            __VERIFIER_error();
+    }
+}

--- a/regression/heap-data/shared_mem1_false/test.desc
+++ b/regression/heap-data/shared_mem1_false/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--heap --values-refine --k-induction
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$

--- a/regression/heap-data/shared_mem2/main.c
+++ b/regression/heap-data/shared_mem2/main.c
@@ -1,4 +1,5 @@
 extern int __VERIFIER_nondet_int();
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <stdlib.h>
 
@@ -41,5 +42,5 @@ int main() {
         list = list->next;
     }
     if (!(m->val == 100))
-        __VERIFIER_nondet_int();
+        __VERIFIER_error();
 }

--- a/regression/heap/array_unwind1/test.desc
+++ b/regression/heap/array_unwind1/test.desc
@@ -1,8 +1,8 @@
-KNOWNBUG
+CORE
 main.c
---incremental-bmc --heap-interval
+--incremental-bmc --heap --intervals
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
-^\[main\.assertion\.1\] assertion \*a\[0\]==0: OK
+^\[main\.assertion\.1\] assertion \*a\[0\]==0: SUCCESS
 ^\[main\.assertion\.2\] assertion \*a\[1\]==2: FAILURE

--- a/regression/heap/array_unwind2/test.desc
+++ b/regression/heap/array_unwind2/test.desc
@@ -1,8 +1,8 @@
-KNOWNBUG
+CORE
 main.c
---incremental-bmc --heap-interval
+--incremental-bmc --heap --intervals
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
 ^\[main\.assertion\.1\] assertion \*a\[0\]==1: FAILURE
-^\[main\.assertion\.2\] assertion \*a\[1\]==1: OK
+^\[main\.assertion\.2\] assertion \*a\[1\]==1: SUCCESS

--- a/regression/heap/list_iter1/test.desc
+++ b/regression/heap/list_iter1/test.desc
@@ -1,10 +1,10 @@
-KNOWNBUG
+CORE
 main.c
---incremental-bmc --independent-properties --heap-interval
+--incremental-bmc --independent-properties --heap --intervals
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
-^\[main\.assertion\.1\] assertion l->n->x==0: OK
+^\[main\.assertion\.1\] assertion l->n->x==0: SUCCESS
 ^\[main\.assertion\.2\] assertion l->n->x==1: FAILURE
 ^\[main\.assertion\.3\] assertion l->x==2: FAILURE
-^\[main\.assertion\.4\] assertion l->x==1: OK
+^\[main\.assertion\.4\] assertion l->x==1: SUCCESS

--- a/regression/heap/list_iter2/test.desc
+++ b/regression/heap/list_iter2/test.desc
@@ -1,10 +1,10 @@
-KNOWNBUG
+CORE
 main.c
---incremental-bmc --independent-properties --heap-interval
+--incremental-bmc --independent-properties --heap --intervals
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
-^\[main\.assertion\.1\] assertion l->n->x==0: OK
-^\[main\.assertion\.2\] assertion l->n->x==1: FAILURE
+^\[main\.assertion\.1\] assertion l->n->x==0: FAILURE
+^\[main\.assertion\.2\] assertion l->n->x==1: SUCCESS
 ^\[main\.assertion\.3\] assertion l->x==2: FAILURE
-^\[main\.assertion\.4\] assertion l->x==1: OK
+^\[main\.assertion\.4\] assertion l->x==1: FAILURE

--- a/regression/heap/list_iter3/main.c
+++ b/regression/heap/list_iter3/main.c
@@ -9,7 +9,7 @@ struct list
 
 void main()
 {
-  struct list *l;
+  struct list *l=NULL;
   struct list *nl1=malloc(sizeof(struct list));
   nl1->x=-1;
   nl1->n=l;

--- a/regression/heap/list_iter3/test.desc
+++ b/regression/heap/list_iter3/test.desc
@@ -1,10 +1,10 @@
-KNOWNBUG
+CORE
 main.c
---incremental-bmc --independent-properties --heap-interval
+--incremental-bmc --independent-properties --heap --intervals
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
-^\[main\.assertion\.1\] assertion l->n->x==0: OK
-^\[main\.assertion\.2\] assertion l->n->x==1: FAILURE
+^\[main\.assertion\.1\] assertion l->n->x==0: FAILURE
+^\[main\.assertion\.2\] assertion l->n->x==1: SUCCESS
 ^\[main\.assertion\.3\] assertion l->x==2: FAILURE
-^\[main\.assertion\.4\] assertion l->x==1: OK
+^\[main\.assertion\.4\] assertion l->x==1: FAILURE

--- a/regression/heap/list_iter4/main.c
+++ b/regression/heap/list_iter4/main.c
@@ -11,11 +11,11 @@ void main()
 {
   struct list *l;
   struct list *nl1=malloc(sizeof(struct list));
-  nl1->x=0;
+  nl1->x=1;
   nl1->n=l;
   l=nl1;
   struct list *nl2=malloc(sizeof(struct list));
-  nl2->x=1;
+  nl2->x=0;
   nl2->n=l;
   l=nl2;
   

--- a/regression/heap/list_iter4/test.desc
+++ b/regression/heap/list_iter4/test.desc
@@ -1,8 +1,8 @@
-KNOWNBUG
+CORE
 main.c
---incremental-bmc --independent-properties --heap-interval
+--incremental-bmc --independent-properties --heap --intervals
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
-^\[main\.assertion\.1\] assertion m->x==i: OK
+^\[main\.assertion\.1\] assertion m->x==i: UNKNOWN
 ^\[main\.assertion\.2\] assertion m->x==-1: FAILURE

--- a/regression/heap/list_unwind1/test.desc
+++ b/regression/heap/list_unwind1/test.desc
@@ -1,8 +1,8 @@
-KNOWNBUG
+CORE
 main.c
---incremental-bmc --heap-interval
+--incremental-bmc --heap --intervals
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
-^\[main\.assertion\.1\] assertion l->n->x==0: OK
+^\[main\.assertion\.1\] assertion l->n->x==0: SUCCESS
 ^\[main\.assertion\.2\] assertion l->x==2: FAILURE

--- a/regression/heap/list_unwind2/test.desc
+++ b/regression/heap/list_unwind2/test.desc
@@ -1,8 +1,8 @@
-KNOWNBUG
+CORE
 main.c
---incremental-bmc --heap-interval
+--incremental-bmc --heap --intervals
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
 ^\[main\.assertion\.1\] assertion l->n->x==1: FAILURE
-^\[main\.assertion\.2\] assertion l->x==1: OK
+^\[main\.assertion\.2\] assertion l->x==1: SUCCESS

--- a/regression/heap/simple_false_kind2/main.c
+++ b/regression/heap/simple_false_kind2/main.c
@@ -1,0 +1,26 @@
+extern int __VERIFIER_nondet_int();
+#include <stdlib.h>
+
+typedef struct node {
+  int h;
+  struct node *n;
+} *List;
+
+int main() {
+  /* Build a list of the form 1->1->2->1->... */
+  List t;
+  List p = 0;
+  int i = 0;
+  while (__VERIFIER_nondet_int()) {
+    t = (List) malloc(sizeof(struct node));
+    t->h = i == 2 ? 2 : 1;
+    t->n = p;
+    p = t;
+    i++;
+  }
+  while (p!=0) {
+    assert(p->h==1);
+    p = p->n;
+  }
+}
+

--- a/regression/heap/simple_false_kind2/test.desc
+++ b/regression/heap/simple_false_kind2/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--heap --intervals --no-propagation --k-induction
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+^\[main.assertion.1\] assertion p->h == 1: FAILURE

--- a/regression/kiki/malloc2/test.desc
+++ b/regression/kiki/malloc2/test.desc
@@ -1,9 +1,6 @@
-KNOWNBUG
+CORE
 main.c
 --inline --havoc --unwind 5
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
---
---
-Needs fix for 6108ad3

--- a/regression/kiki/malloc3/test.desc
+++ b/regression/kiki/malloc3/test.desc
@@ -1,6 +1,6 @@
-KNOWNBUG
+CORE
 main.c
 --inline --havoc --unwind 3
 ^EXIT=10$
 ^SIGNAL=0$
-^** 2 of 5 failed$
+^\*\* 1 of 3 failed$

--- a/regression/memsafety/nondet_free_kind/main.c
+++ b/regression/memsafety/nondet_free_kind/main.c
@@ -1,0 +1,82 @@
+extern int __VERIFIER_nondet_int();
+/*
+ * DLL nondet free example:
+ * Create circular dll (N0-N1-N2), s.t. node Ni is identified by index i.
+ * Then, destroy the dll in nondeterministic order.
+ */
+#include <stdlib.h>
+
+typedef struct node {
+  struct node* next;
+  struct node* prev;
+} *DLL;
+
+void myexit(int s) {
+ _EXIT: goto _EXIT;
+}
+
+DLL dll_circular_create(int len) {
+  DLL last = (DLL) malloc(sizeof(struct node));
+  if(NULL == last) {
+    myexit(1);
+  }
+  last->next = last;
+  last->prev = last;
+  DLL head = last;
+  while(len > 1) {
+    DLL new_head = (DLL) malloc(sizeof(struct node));
+    if(NULL == new_head) {
+      myexit(1);
+    }
+    new_head->next = head;
+    head->prev = new_head;
+    head = new_head;
+    len--;
+  }
+  last->next = head;
+  head->prev = last;
+  return head;
+}
+
+/* dll must be circular and must have exactly 3 nodes */
+void _destroy_in_nondeterministic_order(DLL head) {
+  DLL pred = head->prev;
+  DLL succ = head->next;
+  if(__VERIFIER_nondet_int()) {
+    free(head);
+    if(__VERIFIER_nondet_int()) {
+      free(succ);
+      free(pred);
+    } else {
+      free(pred);
+      free(succ);
+    }
+  } else if(__VERIFIER_nondet_int()) {
+    free(succ);
+    if(__VERIFIER_nondet_int()) {
+      free(head);
+      free(pred);
+    } else {
+      free(pred);
+      free(head);
+    }
+  } else {
+    free(pred);
+    if(__VERIFIER_nondet_int()) {
+      free(head);
+      free(succ);
+    } else {
+      free(succ);
+      free(head);
+    }
+  }
+}
+
+int main() {
+  /* example only works if list has 3 elements */
+  const int len = 3;
+  DLL head = dll_circular_create(len);
+  _destroy_in_nondeterministic_order(head);
+  head = NULL;
+  return 0;
+}

--- a/regression/memsafety/nondet_free_kind/test.desc
+++ b/regression/memsafety/nondet_free_kind/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--heap --pointer-check --memory-leak-check --k-induction
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$

--- a/regression/memsafety/nondet_free_leak_kind/main.c
+++ b/regression/memsafety/nondet_free_leak_kind/main.c
@@ -1,0 +1,84 @@
+extern int __VERIFIER_nondet_int();
+/*
+ * DLL nondet free example:
+ * Create circular dll (N0-N1-N2), s.t. node Ni is identified by index i.
+ * Then, destroy the dll in nondeterministic order.
+ * Violation: Do not destroy the second node if the index order is: 2-1-0.
+ */
+#include <stdlib.h>
+
+typedef struct node {
+  struct node* next;
+  struct node* prev;
+} *DLL;
+
+void myexit(int s) {
+ _EXIT: goto _EXIT;
+}
+
+DLL dll_circular_create(int len) {
+  DLL last = (DLL) malloc(sizeof(struct node));
+  if(NULL == last) {
+    myexit(1);
+  }
+  last->next = last;
+  last->prev = last;
+  DLL head = last;
+  while(len > 1) {
+    DLL new_head = (DLL) malloc(sizeof(struct node));
+    if(NULL == new_head) {
+      myexit(1);
+    }
+    new_head->next = head;
+    head->prev = new_head;
+    head = new_head;
+    len--;
+  }
+  last->next = head;
+  head->prev = last;
+  return head;
+}
+
+/* dll must be circular and must have exactly 3 nodes */
+void _destroy_in_nondeterministic_order(DLL head) {
+  DLL pred = head->prev;
+  DLL succ = head->next;
+  if(__VERIFIER_nondet_int()) {
+    free(head);
+    if(__VERIFIER_nondet_int()) {
+      free(succ);
+      free(pred);
+    } else {
+      free(pred);
+      free(succ);
+    }
+  } else if(__VERIFIER_nondet_int()) {
+    free(succ);
+    if(__VERIFIER_nondet_int()) {
+      free(head);
+      free(pred);
+    } else {
+      free(pred);
+      free(head);
+    }
+  } else {
+    free(pred);
+    if(__VERIFIER_nondet_int()) {
+      free(head);
+      free(succ);
+    } else {
+      /* memory leak: successor should be deallocated here */
+      free(head);
+    }
+  }
+}
+
+int main() {
+  /* example only works if list has 3 elements */
+  const int len = 3;
+  DLL head = dll_circular_create(len);
+  /* next function call causes memory leak */
+  _destroy_in_nondeterministic_order(head);
+  head = NULL;
+  return 0;
+}

--- a/regression/memsafety/nondet_free_leak_kind/test.desc
+++ b/regression/memsafety/nondet_free_leak_kind/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--heap --pointer-check --memory-leak-check --k-induction
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+\[__CPROVER__start.memory-leak.1\] dynamically allocated memory never freed in __CPROVER_memory_leak == NULL: FAILURE

--- a/regression/memsafety/null_deref_kind/main.c
+++ b/regression/memsafety/null_deref_kind/main.c
@@ -1,0 +1,29 @@
+extern int __VERIFIER_nondet_int();
+#include <assert.h>
+#include <stdlib.h>
+
+struct list
+{
+  int x;
+  struct list *n;
+};
+
+void main()
+{
+  struct list *l=NULL;
+  while(__VERIFIER_nondet_int())
+  {
+    struct list *n=malloc(sizeof(struct list));
+    n->n=l;
+    n->x=1;
+    l=n;
+  }
+
+  // Jump twice each time
+  while(l!=NULL)
+  {
+    assert(l->x==1);
+    l=l->n;
+    l=l->n;
+  }
+}

--- a/regression/memsafety/null_deref_kind/test.desc
+++ b/regression/memsafety/null_deref_kind/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--heap --intervals --pointer-check --k-induction
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+\[main.pointer_dereference.25\] dereference failure: pointer NULL in l->n: FAILURE

--- a/regression/memsafety/simple_leak_kind/main.c
+++ b/regression/memsafety/simple_leak_kind/main.c
@@ -1,0 +1,50 @@
+extern int __VERIFIER_nondet_int();
+/*
+ * Simpler regression reproducer inspired by nondet_free_kind
+ */
+#include <stdlib.h>
+
+typedef struct node {
+  struct node* next;
+  struct node* prev;
+} *DLL;
+
+void myexit(int s) {
+ _EXIT: goto _EXIT;
+}
+
+DLL dll_circular_create(int len) {
+  DLL last = (DLL) malloc(sizeof(struct node));
+  if(NULL == last) {
+    myexit(1);
+  }
+  last->next = last;
+  last->prev = last;
+  DLL head = last;
+  while(len > 1) {
+    DLL new_head = (DLL) malloc(sizeof(struct node));
+    if(NULL == new_head) {
+      myexit(1);
+    }
+    new_head->next = head;
+    head->prev = new_head;
+    head = new_head;
+    len--;
+  }
+  last->next = head;
+  head->prev = last;
+  return head;
+}
+
+void _destroy(DLL head) {
+  free(head);
+}
+
+int main() {
+  const int len = 2;
+  DLL head = dll_circular_create(len);
+  /* next function call causes memory leak */
+  _destroy(head);
+  head = NULL;
+  return 0;
+}

--- a/regression/memsafety/simple_leak_kind/test.desc
+++ b/regression/memsafety/simple_leak_kind/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--heap --pointer-check --memory-leak-check --k-induction
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+\[__CPROVER__start.memory-leak.1\] dynamically allocated memory never freed in __CPROVER_memory_leak == NULL: FAILURE

--- a/src/2ls/2ls_parse_options.cpp
+++ b/src/2ls/2ls_parse_options.cpp
@@ -578,18 +578,18 @@ int twols_parse_optionst::doit()
     if(!options.get_bool_option("k-induction") &&
        !options.get_bool_option("incremental-bmc"))
       checker=std::unique_ptr<summary_checker_baset>(
-        new summary_checker_ait(options));
+        new summary_checker_ait(options, goto_model));
     if(options.get_bool_option("k-induction") &&
        !options.get_bool_option("incremental-bmc"))
       checker=std::unique_ptr<summary_checker_baset>(
-        new summary_checker_kindt(options));
+        new summary_checker_kindt(options, goto_model));
     if(!options.get_bool_option("k-induction") &&
        options.get_bool_option("incremental-bmc"))
       checker=std::unique_ptr<summary_checker_baset>(
-        new summary_checker_bmct(options));
+        new summary_checker_bmct(options, goto_model));
     if(options.get_bool_option("nontermination"))
       checker=std::unique_ptr<summary_checker_baset>(
-        new summary_checker_nontermt(options));
+        new summary_checker_nontermt(options, goto_model));
 
     checker->set_message_handler(get_message_handler());
     checker->simplify=!cmdline.isset("no-simplify");
@@ -600,7 +600,7 @@ int twols_parse_optionst::doit()
     {
       std::cout << "VERIFICATION CONDITIONS:\n\n";
       checker->show_vcc=true;
-      (*checker)(goto_model);
+      (*checker)();
       return 0;
     }
 
@@ -639,7 +639,7 @@ int twols_parse_optionst::doit()
       !options.get_bool_option("termination") &&
       !options.get_bool_option("nontermination");
     // do actual analysis
-    switch((*checker)(goto_model))
+    switch((*checker)())
     {
     case resultt::PASS:
       if(report_assertions)

--- a/src/2ls/2ls_parse_options.cpp
+++ b/src/2ls/2ls_parse_options.cpp
@@ -560,6 +560,7 @@ int twols_parse_optionst::doit()
   {
     status() << "Using GOTO unwinder due to presence of dynamic memory" << eom;
     options.set_option("unwind-goto", true);
+    options.set_option("dynamic-memory", true);
   }
   // don't do nontermination with dynamic memory
   if(options.get_bool_option("competition-mode") &&

--- a/src/2ls/2ls_parse_options.cpp
+++ b/src/2ls/2ls_parse_options.cpp
@@ -1122,6 +1122,9 @@ bool twols_parse_optionst::process_goto_program(
     if(options.get_bool_option("memory-leak-check"))
       allow_record_memleak(goto_model);
 
+    for(auto &f_it : goto_model.goto_functions.function_map)
+      split_memory_leak_assignments(f_it.second.body, goto_model.symbol_table);
+    goto_model.goto_functions.update();
     split_same_symbolic_object_assignments(goto_model);
 
     // remove loop heads from function entries

--- a/src/2ls/2ls_parse_options.cpp
+++ b/src/2ls/2ls_parse_options.cpp
@@ -550,15 +550,16 @@ int twols_parse_optionst::doit()
     status() << eom;
   }
 
-  // don't use k-induction with dynamic memory
-  if(options.get_bool_option("competition-mode") &&
-     options.get_bool_option("k-induction") &&
+  // turn on slower GOTO unwinder when dynamic memory and unwinding
+  // is combined
+  if((options.get_bool_option("k-induction") ||
+      options.get_bool_option("incremental-bmc") ||
+      options.get_unsigned_int_option("unwind")) &&
+     !options.get_bool_option("nontermination") &&
      dynamic_memory_detected)
   {
-    options.set_option("k-induction", false);
-    options.set_option("std-invariants", false);
-    options.set_option("incremental-bmc", false);
-    options.set_option("unwind", 0);
+    status() << "Using GOTO unwinder due to presence of dynamic memory" << eom;
+    options.set_option("unwind-goto", true);
   }
   // don't do nontermination with dynamic memory
   if(options.get_bool_option("competition-mode") &&

--- a/src/2ls/dynamic_cfg.cpp
+++ b/src/2ls/dynamic_cfg.cpp
@@ -17,7 +17,7 @@ Author: Peter Schrammel
 
 /// generates the dynamic CFG
 void dynamic_cfgt::operator()(
-  const ssa_local_unwindert &ssa_unwinder,
+  const local_unwindert &ssa_unwinder,
   const unwindable_local_SSAt &ssa,
   const summaryt &summary)
 {
@@ -46,7 +46,7 @@ void dynamic_cfgt::add_assumptions(const assumptionst &assumptions)
 /// extracts assumptions from invariants
 void dynamic_cfgt::build_cfg(
   const goto_programt &goto_program,
-  const ssa_local_unwindert &ssa_unwinder)
+  const local_unwindert &ssa_unwinder)
 {
   std::vector<unsigned> iteration_stack;
   std::vector<node_indext> loop_node_stack;

--- a/src/2ls/dynamic_cfg.h
+++ b/src/2ls/dynamic_cfg.h
@@ -16,7 +16,7 @@ Author: Peter Schrammel
 #include <util/graph.h>
 #include <goto-programs/goto_program.h>
 
-#include <ssa/ssa_unwinder.h>
+#include <ssa/unwinder.h>
 #include <ssa/unwindable_local_ssa.h>
 #include <solver/summary.h>
 
@@ -73,7 +73,7 @@ public:
 
   // TODO: generalise this to non-inlined programs
   void operator()(
-    const ssa_local_unwindert &ssa_unwinder,
+    const local_unwindert &ssa_unwinder,
     const unwindable_local_SSAt &ssa,
     const summaryt &summary);
 
@@ -83,7 +83,7 @@ protected:
 
   void build_cfg(
     const goto_programt &goto_program,
-    const ssa_local_unwindert &ssa_unwinder);
+    const local_unwindert &ssa_unwinder);
 
   void build_from_invariants(
     const unwindable_local_SSAt &ssa,

--- a/src/2ls/graphml_witness_ext.cpp
+++ b/src/2ls/graphml_witness_ext.cpp
@@ -11,6 +11,8 @@ Author: Peter Schrammel
 
 #include "graphml_witness_ext.h"
 
+#include <ssa/unwinder.h>
+
 /// proof witness TODO: works only for inlined programs
 void graphml_witness_extt::operator()(
   const summary_checker_baset &summary_checker)
@@ -19,8 +21,8 @@ void graphml_witness_extt::operator()(
   const unwindable_local_SSAt &ssa=
     static_cast<const unwindable_local_SSAt &>(
       summary_checker.ssa_db.get(function_name));
-  const ssa_local_unwindert &ssa_unwinder=
-  summary_checker.ssa_unwinder.get(function_name);
+  const local_unwindert &ssa_unwinder=
+  summary_checker.ssa_unwinder->get(function_name);
 
   graphml.key_values["sourcecodelang"]="C";
 

--- a/src/2ls/instrument_goto.h
+++ b/src/2ls/instrument_goto.h
@@ -16,7 +16,6 @@ Author: Peter Schrammel, Björn Wachter
 #include <util/options.h>
 
 #include <ssa/local_ssa.h>
-#include <ssa/ssa_unwinder.h>
 #include <ssa/ssa_db.h>
 #include <solver/summary_db.h>
 

--- a/src/2ls/preprocessing_util.cpp
+++ b/src/2ls/preprocessing_util.cpp
@@ -616,6 +616,14 @@ void twols_parse_optionst::create_dynobj_instances(
           nondet.pretty_name=nondet.name;
           symbol_table.add(nondet);
 
+          const exprt nondet_bool_expr =
+            side_effect_expr_nondett(bool_typet(), it->source_location);
+          goto_program.insert_before(
+            it,
+            goto_programt::make_assignment(
+              code_assignt(nondet.symbol_expr(), nondet_bool_expr),
+              it->source_location));
+
           suffix="$"+std::to_string(i);
           obj_symbol.name=name+suffix;
           obj_symbol.base_name=base_name+suffix;

--- a/src/2ls/preprocessing_util.cpp
+++ b/src/2ls/preprocessing_util.cpp
@@ -251,7 +251,7 @@ void twols_parse_optionst::remove_multiple_dereferences(goto_modelt &goto_model)
   {
     Forall_goto_program_instructions(i_it, f_it.second.body)
     {
-      if(i_it->is_goto())
+      if(i_it->is_goto() || i_it->is_assert())
       {
         remove_multiple_dereferences(
           goto_model,

--- a/src/2ls/summary_checker_ai.cpp
+++ b/src/2ls/summary_checker_ai.cpp
@@ -10,6 +10,7 @@ Author: Peter Schrammel
 /// Summary Checker for AI
 
 #include "summary_checker_ai.h"
+#include <ssa/unwinder.h>
 #include <ssa/ssa_build_goto_trace.h>
 
 resultt summary_checker_ait::operator()(
@@ -17,7 +18,7 @@ resultt summary_checker_ait::operator()(
 {
   SSA_functions(goto_model, goto_model.symbol_table);
 
-  ssa_unwinder.init(false, false);
+  ssa_unwinder.init(unwinder_modet::NORMAL);
 
   unsigned unwind=options.get_unsigned_int_option("unwind");
   if(unwind>0)

--- a/src/2ls/summary_checker_ai.cpp
+++ b/src/2ls/summary_checker_ai.cpp
@@ -18,16 +18,16 @@ resultt summary_checker_ait::operator()(
 {
   SSA_functions(goto_model, goto_model.symbol_table);
 
-  ssa_unwinder.init(unwinder_modet::NORMAL);
+  ssa_unwinder->init(unwinder_modet::NORMAL);
 
   unsigned unwind=options.get_unsigned_int_option("unwind");
   if(unwind>0)
   {
     status() << "Unwinding" << messaget::eom;
 
-    ssa_unwinder.init_localunwinders();
+    ssa_unwinder->init_localunwinders();
 
-    ssa_unwinder.unwind_all(unwind);
+    ssa_unwinder->unwind_all(unwind);
   }
 
   // properties

--- a/src/2ls/summary_checker_ai.cpp
+++ b/src/2ls/summary_checker_ai.cpp
@@ -13,8 +13,7 @@ Author: Peter Schrammel
 #include <ssa/unwinder.h>
 #include <ssa/ssa_build_goto_trace.h>
 
-resultt summary_checker_ait::operator()(
-  const goto_modelt &goto_model)
+resultt summary_checker_ait::operator()()
 {
   SSA_functions(goto_model, goto_model.symbol_table);
 

--- a/src/2ls/summary_checker_ai.h
+++ b/src/2ls/summary_checker_ai.h
@@ -17,10 +17,12 @@ Author: Peter Schrammel
 class summary_checker_ait:public summary_checker_baset
 {
 public:
-  explicit inline summary_checker_ait(optionst &_options):
-    summary_checker_baset(_options) {}
+  explicit inline summary_checker_ait(
+    optionst &_options,
+    goto_modelt &_goto_model):
+    summary_checker_baset(_options, _goto_model) {}
 
-  virtual resultt operator()(const goto_modelt &);
+  resultt operator()() override;
 
 protected:
   void report_preconditions();

--- a/src/2ls/summary_checker_base.cpp
+++ b/src/2ls/summary_checker_base.cpp
@@ -26,7 +26,6 @@ Author: Peter Schrammel
 #include <ssa/simplify_ssa.h>
 #include <ssa/ssa_build_goto_trace.h>
 #include <domains/ssa_analyzer.h>
-#include <ssa/ssa_unwinder.h>
 
 #include <solver/summarizer_fw.h>
 #include <solver/summarizer_fw_term.h>
@@ -375,7 +374,7 @@ exprt::operandst summary_checker_baset::get_loophead_selects(
       continue;
     symbol_exprt lsguard=
       SSA.name(SSA.guard_symbol(), local_SSAt::LOOP_SELECT, n_it->location);
-    ssa_unwinder.get(function_name).unwinder_rename(lsguard, *n_it, true);
+    ssa_unwinder->get(function_name).unwinder_rename(lsguard, *n_it, true);
     loophead_selects.push_back(not_exprt(lsguard));
     solver.set_frozen(solver.convert(lsguard));
   }
@@ -402,7 +401,7 @@ exprt::operandst summary_checker_baset::get_loop_continues(
   // TODO: this should be provided by unwindable_local_SSA
   exprt::operandst loop_continues;
 
-  ssa_unwinder.get(function_name).loop_continuation_conditions(loop_continues);
+  ssa_unwinder->get(function_name).loop_continuation_conditions(loop_continues);
   if(loop_continues.size()==0)
   {
     // TODO: this should actually be done transparently by the unwinder

--- a/src/2ls/summary_checker_base.h
+++ b/src/2ls/summary_checker_base.h
@@ -18,6 +18,7 @@ Author: Peter Schrammel
 #include <util/ui_message.h>
 
 #include <ssa/local_ssa.h>
+#include <ssa/unwinder.h>
 #include <ssa/ssa_unwinder.h>
 #include <ssa/ssa_inliner.h>
 #include <domains/incremental_solver.h>
@@ -40,7 +41,7 @@ public:
     fixed_point(false),
     options(_options),
     ssa_db(_options), summary_db(),
-    ssa_unwinder(ssa_db),
+    ssa_unwinder(new ssa_unwindert(ssa_db)),
     ssa_inliner(summary_db),
     solver_instances(0),
     solver_calls(0),
@@ -73,7 +74,7 @@ protected:
 
   ssa_dbt ssa_db;
   summary_dbt summary_db;
-  ssa_unwindert ssa_unwinder;
+  std::unique_ptr<unwindert> ssa_unwinder;
   ssa_inlinert ssa_inliner;
 
   unsigned solver_instances;

--- a/src/2ls/summary_checker_base.h
+++ b/src/2ls/summary_checker_base.h
@@ -20,6 +20,7 @@ Author: Peter Schrammel
 #include <ssa/local_ssa.h>
 #include <ssa/unwinder.h>
 #include <ssa/ssa_unwinder.h>
+#include <ssa/goto_unwinder.h>
 #include <ssa/ssa_inliner.h>
 #include <domains/incremental_solver.h>
 #include <ssa/ssa_db.h>
@@ -35,13 +36,15 @@ class summary_checker_baset:public messaget
 {
 public:
   summary_checker_baset(
-    optionst &_options):
+    optionst &_options,
+    goto_modelt &_goto_model):
     show_vcc(false),
     simplify(false),
     fixed_point(false),
     options(_options),
+    goto_model(_goto_model),
     ssa_db(_options), summary_db(),
-    ssa_unwinder(new ssa_unwindert(ssa_db)),
+    ssa_unwinder(new goto_unwindert(ssa_db, _goto_model, simplify)),
     ssa_inliner(summary_db),
     solver_instances(0),
     solver_calls(0),
@@ -51,7 +54,7 @@ public:
   bool show_vcc, simplify, fixed_point;
   irep_idt function_to_check;
 
-  virtual resultt operator()(const goto_modelt &) { assert(false); }
+  virtual resultt operator()() { assert(false); }
 
   void instrument_and_output(
     goto_modelt &goto_model,
@@ -72,6 +75,7 @@ public:
 protected:
   optionst &options;
 
+  goto_modelt &goto_model;
   ssa_dbt ssa_db;
   summary_dbt summary_db;
   std::unique_ptr<unwindert> ssa_unwinder;

--- a/src/2ls/summary_checker_base.h
+++ b/src/2ls/summary_checker_base.h
@@ -16,6 +16,7 @@ Author: Peter Schrammel
 #include <goto-checker/properties.h>
 #include <goto-checker/goto_trace_storage.h>
 #include <util/ui_message.h>
+#include <util/make_unique.h>
 
 #include <ssa/local_ssa.h>
 #include <ssa/unwinder.h>
@@ -44,12 +45,19 @@ public:
     options(_options),
     goto_model(_goto_model),
     ssa_db(_options), summary_db(),
-    ssa_unwinder(new goto_unwindert(ssa_db, _goto_model, simplify)),
+    ssa_unwinder(util_make_unique<ssa_unwindert>(ssa_db)),
     ssa_inliner(summary_db),
     solver_instances(0),
     solver_calls(0),
     summaries_used(0),
-    termargs_computed(0) {}
+    termargs_computed(0)
+  {
+    if(options.get_bool_option("unwind-goto"))
+      ssa_unwinder=util_make_unique<goto_unwindert>(
+        ssa_db,
+        goto_model,
+        simplify);
+  }
 
   bool show_vcc, simplify, fixed_point;
   irep_idt function_to_check;

--- a/src/2ls/summary_checker_base.h
+++ b/src/2ls/summary_checker_base.h
@@ -56,7 +56,8 @@ public:
       ssa_unwinder=util_make_unique<goto_unwindert>(
         ssa_db,
         goto_model,
-        simplify);
+        simplify,
+        options.get_bool_option("dynamic-memory"));
   }
 
   bool show_vcc, simplify, fixed_point;

--- a/src/2ls/summary_checker_bmc.cpp
+++ b/src/2ls/summary_checker_bmc.cpp
@@ -9,6 +9,7 @@ Author: Peter Schrammel
 /// \file
 /// Summary Checker for BMC
 
+#include <ssa/unwinder.h>
 #include "summary_checker_bmc.h"
 
 
@@ -17,7 +18,7 @@ resultt summary_checker_bmct::operator()(
 {
   SSA_functions(goto_model, goto_model.symbol_table);
 
-  ssa_unwinder.init(false, true);
+  ssa_unwinder.init(unwinder_modet::BMC);
 
   resultt result=resultt::UNKNOWN;
   unsigned max_unwind=options.get_unsigned_int_option("unwind");

--- a/src/2ls/summary_checker_bmc.cpp
+++ b/src/2ls/summary_checker_bmc.cpp
@@ -18,18 +18,18 @@ resultt summary_checker_bmct::operator()(
 {
   SSA_functions(goto_model, goto_model.symbol_table);
 
-  ssa_unwinder.init(unwinder_modet::BMC);
+  ssa_unwinder->init(unwinder_modet::BMC);
 
   resultt result=resultt::UNKNOWN;
   unsigned max_unwind=options.get_unsigned_int_option("unwind");
   status() << "Max-unwind is " << max_unwind << eom;
-  ssa_unwinder.init_localunwinders();
+  ssa_unwinder->init_localunwinders();
 
   for(unsigned unwind=0; unwind<=max_unwind; unwind++)
   {
     status() << "Unwinding (k=" << unwind << ")" << messaget::eom;
     summary_db.mark_recompute_all();
-    ssa_unwinder.unwind_all(unwind);
+    ssa_unwinder->unwind_all(unwind);
     result=check_properties();
     if(result==resultt::PASS)
     {

--- a/src/2ls/summary_checker_bmc.cpp
+++ b/src/2ls/summary_checker_bmc.cpp
@@ -13,8 +13,7 @@ Author: Peter Schrammel
 #include "summary_checker_bmc.h"
 
 
-resultt summary_checker_bmct::operator()(
-  const goto_modelt &goto_model)
+resultt summary_checker_bmct::operator()()
 {
   SSA_functions(goto_model, goto_model.symbol_table);
 

--- a/src/2ls/summary_checker_bmc.h
+++ b/src/2ls/summary_checker_bmc.h
@@ -17,10 +17,10 @@ Author: Peter Schrammel
 class summary_checker_bmct:public summary_checker_baset
 {
 public:
-  explicit summary_checker_bmct(optionst &_options):
-    summary_checker_baset(_options) {}
+  explicit summary_checker_bmct(optionst &_options, goto_modelt &_goto_model):
+    summary_checker_baset(_options, _goto_model) {}
 
-  virtual resultt operator()(const goto_modelt &);
+  resultt operator()() override;
 };
 
 #endif

--- a/src/2ls/summary_checker_kind.cpp
+++ b/src/2ls/summary_checker_kind.cpp
@@ -13,8 +13,7 @@ Author: Peter Schrammel
 
 #include "summary_checker_kind.h"
 
-resultt summary_checker_kindt::operator()(
-  const goto_modelt &goto_model)
+resultt summary_checker_kindt::operator()()
 {
   SSA_functions(goto_model, goto_model.symbol_table);
 

--- a/src/2ls/summary_checker_kind.cpp
+++ b/src/2ls/summary_checker_kind.cpp
@@ -18,14 +18,14 @@ resultt summary_checker_kindt::operator()(
 {
   SSA_functions(goto_model, goto_model.symbol_table);
 
-  ssa_unwinder.init(unwinder_modet::K_INDUCTION);
+  ssa_unwinder->init(unwinder_modet::K_INDUCTION);
 
   resultt result=resultt::UNKNOWN;
   unsigned max_unwind=options.get_unsigned_int_option("unwind");
   unsigned give_up_invariants=
     options.get_unsigned_int_option("give-up-invariants");
   status() << "Max-unwind is " << max_unwind << eom;
-  ssa_unwinder.init_localunwinders();
+  ssa_unwinder->init_localunwinders();
 
   for(unsigned unwind=0; unwind<=max_unwind; unwind++)
   {
@@ -34,7 +34,7 @@ resultt summary_checker_kindt::operator()(
     // TODO: recompute only functions with loops
     summary_db.mark_recompute_all();
 
-    ssa_unwinder.unwind_all(unwind);
+    ssa_unwinder->unwind_all(unwind);
 
     result=check_properties();
     bool magic_limit_not_reached=

--- a/src/2ls/summary_checker_kind.cpp
+++ b/src/2ls/summary_checker_kind.cpp
@@ -9,6 +9,8 @@ Author: Peter Schrammel
 /// \file
 /// Summary Checker for k-induction
 
+#include <ssa/unwinder.h>
+
 #include "summary_checker_kind.h"
 
 resultt summary_checker_kindt::operator()(
@@ -16,7 +18,7 @@ resultt summary_checker_kindt::operator()(
 {
   SSA_functions(goto_model, goto_model.symbol_table);
 
-  ssa_unwinder.init(true, false);
+  ssa_unwinder.init(unwinder_modet::K_INDUCTION);
 
   resultt result=resultt::UNKNOWN;
   unsigned max_unwind=options.get_unsigned_int_option("unwind");

--- a/src/2ls/summary_checker_kind.h
+++ b/src/2ls/summary_checker_kind.h
@@ -17,10 +17,12 @@ Author: Peter Schrammel
 class summary_checker_kindt:public summary_checker_baset
 {
 public:
-  explicit inline summary_checker_kindt(optionst &_options):
-    summary_checker_baset(_options) {}
+  explicit inline summary_checker_kindt(
+    optionst &_options,
+    goto_modelt &_goto_model):
+    summary_checker_baset(_options, _goto_model) {}
 
-  virtual resultt operator()(const goto_modelt &);
+  resultt operator()() override;
 };
 
 #endif

--- a/src/2ls/summary_checker_nonterm.cpp
+++ b/src/2ls/summary_checker_nonterm.cpp
@@ -20,8 +20,7 @@ Author: Stefan Marticek
 
 #include <limits>
 
-resultt summary_checker_nontermt::operator()(
-  const goto_modelt &goto_model)
+resultt summary_checker_nontermt::operator()()
 {
   SSA_functions(goto_model, goto_model.symbol_table);
 

--- a/src/2ls/summary_checker_nonterm.cpp
+++ b/src/2ls/summary_checker_nonterm.cpp
@@ -15,6 +15,7 @@ Author: Stefan Marticek
 #include <util/prefix.h>
 
 #include <ssa/simplify_ssa.h>
+#include <ssa/unwinder.h>
 #include <2ls/show.h>
 
 #include <limits>
@@ -24,7 +25,7 @@ resultt summary_checker_nontermt::operator()(
 {
   SSA_functions(goto_model, goto_model.symbol_table);
 
-  ssa_unwinder.init(false, true);
+  ssa_unwinder.init(unwinder_modet::BMC);
 
   resultt result=resultt::UNKNOWN;
   unsigned max_unwind=options.get_unsigned_int_option("unwind");

--- a/src/2ls/summary_checker_nonterm.cpp
+++ b/src/2ls/summary_checker_nonterm.cpp
@@ -25,17 +25,17 @@ resultt summary_checker_nontermt::operator()(
 {
   SSA_functions(goto_model, goto_model.symbol_table);
 
-  ssa_unwinder.init(unwinder_modet::BMC);
+  ssa_unwinder->init(unwinder_modet::BMC);
 
   resultt result=resultt::UNKNOWN;
   unsigned max_unwind=options.get_unsigned_int_option("unwind");
   status() << "Max-unwind is " << max_unwind << eom;
-  ssa_unwinder.init_localunwinders();
+  ssa_unwinder->init_localunwinders();
 
   for(unsigned unwind=1; unwind<=max_unwind; unwind++)
   {
     status() << "Unwinding (k=" << unwind << ")" << messaget::eom;
-    ssa_unwinder.unwind_all(unwind);
+    ssa_unwinder->unwind_all(unwind);
     if(unwind==51)  // use a different nontermination technique
     {
       result=check_nonterm_linear();
@@ -79,7 +79,7 @@ void summary_checker_nontermt::check_properties(
 {
   unwindable_local_SSAt &SSA=*f_it->second;
 
-  ssa_local_unwindert &ssa_local_unwinder=ssa_unwinder.get(f_it->first);
+  local_unwindert &ssa_local_unwinder=ssa_unwinder->get(f_it->first);
 
 #if 0
   SSA.output_verbose(std::cout);
@@ -215,7 +215,7 @@ void summary_checker_nontermt::check_properties_linear(
 {
   unwindable_local_SSAt &SSA=*f_it->second;
 
-  ssa_local_unwindert &ssa_local_unwinder=ssa_unwinder.get(f_it->first);
+  local_unwindert &ssa_local_unwinder=ssa_unwinder->get(f_it->first);
 
   // solver
   incremental_solvert &solver=ssa_db.get_solver(f_it->first);

--- a/src/2ls/summary_checker_nonterm.h
+++ b/src/2ls/summary_checker_nonterm.h
@@ -17,12 +17,14 @@ Author: Stefan Marticek
 class summary_checker_nontermt:public summary_checker_baset
 {
 public:
-  explicit summary_checker_nontermt(optionst &_options):
-    summary_checker_baset(_options)
+  explicit summary_checker_nontermt(
+    optionst &_options,
+    goto_modelt &_goto_model):
+    summary_checker_baset(_options, _goto_model)
   {
   }
 
-  virtual resultt operator()(const goto_modelt &);
+  virtual resultt operator()();
 
   void check_properties(
     const ssa_dbt::functionst::const_iterator f_it);

--- a/src/domains/template_generator_base.h
+++ b/src/domains/template_generator_base.h
@@ -16,7 +16,8 @@ Author: Peter Schrammel
 #include <util/replace_expr.h>
 
 #include <ssa/local_ssa.h>
-#include <ssa/ssa_unwinder.h>
+#include <ssa/ssa_db.h>
+#include <ssa/unwinder.h>
 #include "strategy_solver_base.h"
 
 // #define SHOW_TEMPLATE_VARIABLES
@@ -30,7 +31,7 @@ public:
   explicit template_generator_baset(
     optionst &_options,
     ssa_dbt &_ssa_db,
-    ssa_local_unwindert &_ssa_local_unwinder):
+    local_unwindert &_ssa_local_unwinder):
     options(_options), ssa_db(_ssa_db),
     ssa_local_unwinder(_ssa_local_unwinder)
   {
@@ -69,7 +70,7 @@ public:
 
 protected:
   const ssa_dbt &ssa_db;
-  const ssa_local_unwindert &ssa_local_unwinder;
+  const local_unwindert &ssa_local_unwinder;
   std::unique_ptr<domaint> domain_ptr;
   bool std_invariants; // include value at loop entry
 

--- a/src/domains/template_generator_callingcontext.h
+++ b/src/domains/template_generator_callingcontext.h
@@ -14,13 +14,15 @@ Author: Peter Schrammel
 
 #include "template_generator_base.h"
 
+#include <ssa/unwinder.h>
+
 class template_generator_callingcontextt:public template_generator_baset
 {
 public:
   explicit template_generator_callingcontextt(
     optionst &_options,
     ssa_dbt &_ssa_db,
-    ssa_local_unwindert &_ssa_local_unwinder):
+    local_unwindert &_ssa_local_unwinder):
     template_generator_baset(_options, _ssa_db, _ssa_local_unwinder)
   {
   }

--- a/src/domains/template_generator_ranking.h
+++ b/src/domains/template_generator_ranking.h
@@ -14,13 +14,16 @@ Author: Peter Schrammel
 
 #include "template_generator_base.h"
 
+#include <ssa/ssa_db.h>
+#include <ssa/unwinder.h>
+
 class template_generator_rankingt:public template_generator_baset
 {
 public:
   explicit template_generator_rankingt(
     optionst &_options,
     ssa_dbt &_ssa_db,
-    ssa_local_unwindert &_ssa_local_unwinder):
+    local_unwindert &_ssa_local_unwinder):
   template_generator_baset(_options, _ssa_db, _ssa_local_unwinder)
   {
   }

--- a/src/domains/template_generator_summary.h
+++ b/src/domains/template_generator_summary.h
@@ -12,6 +12,9 @@ Author: Peter Schrammel
 #ifndef CPROVER_2LS_DOMAINS_TEMPLATE_GENERATOR_SUMMARY_H
 #define CPROVER_2LS_DOMAINS_TEMPLATE_GENERATOR_SUMMARY_H
 
+#include <ssa/ssa_db.h>
+#include <ssa/unwinder.h>
+
 #include "template_generator_base.h"
 
 class template_generator_summaryt:public template_generator_baset
@@ -20,7 +23,7 @@ public:
   explicit template_generator_summaryt(
     optionst &_options,
     ssa_dbt &_ssa_db,
-    ssa_local_unwindert &_ssa_local_unwinder):
+    local_unwindert &_ssa_local_unwinder):
     template_generator_baset(_options, _ssa_db, _ssa_local_unwinder)
   {
   }

--- a/src/domains/util.cpp
+++ b/src/domains/util.cpp
@@ -610,3 +610,17 @@ std::string get_dynobj_instance(const irep_idt &id)
   size_t end=name.find_first_not_of("0123456789co", start);
   return name.substr(start, end-start);
 }
+
+/// Replaces usages of a symbol with another symbol in the given expression.
+void replace_symbol(exprt &expr, const irep_idt &old, const irep_idt &updated)
+{
+  if(expr.id()==ID_symbol)
+  {
+    auto &symbol_expr=to_symbol_expr(expr);
+    if(symbol_expr.get_identifier()==old)
+      symbol_expr.set_identifier(updated);
+  }
+  else
+    for(auto &op : expr.operands())
+      replace_symbol(op, old, updated);
+}

--- a/src/domains/util.h
+++ b/src/domains/util.h
@@ -43,5 +43,6 @@ bool is_cprover_symbol(const exprt &expr);
 
 int get_dynobj_line(const irep_idt &id);
 std::string get_dynobj_instance(const irep_idt &id);
+void replace_symbol(exprt &expr, const irep_idt &old, const irep_idt &updated);
 
 #endif

--- a/src/solver/summarizer_base.cpp
+++ b/src/solver/summarizer_base.cpp
@@ -91,7 +91,7 @@ bool summarizer_baset::check_call_reachable(
   solver << ssa_inliner.get_summaries(SSA);
 
   symbol_exprt guard=SSA.guard_symbol(n_it->location);
-  ssa_unwinder.get(function_name).unwinder_rename(guard, *n_it, false);
+  ssa_unwinder->get(function_name).unwinder_rename(guard, *n_it, false);
   solver << guard;
 
 #if 0
@@ -159,7 +159,7 @@ exprt summarizer_baset::compute_calling_context(
   analyzer.set_message_handler(get_message_handler());
 
   template_generator_callingcontextt template_generator(
-    options, ssa_db, ssa_unwinder.get(function_name));
+    options, ssa_db, ssa_unwinder->get(function_name));
   template_generator.set_message_handler(get_message_handler());
   template_generator(solver.next_domain_number(), SSA, n_it, f_it, forward);
 

--- a/src/solver/summarizer_base.h
+++ b/src/solver/summarizer_base.h
@@ -16,7 +16,7 @@ Author: Peter Schrammel
 #include <util/options.h>
 
 #include <ssa/ssa_inliner.h>
-#include <ssa/ssa_unwinder.h>
+#include <ssa/unwinder.h>
 #include <ssa/local_ssa.h>
 #include <ssa/ssa_db.h>
 
@@ -27,7 +27,7 @@ public:
     optionst &_options,
     summary_dbt &_summary_db,
     ssa_dbt &_ssa_db,
-    ssa_unwindert &_ssa_unwinder,
+    std::unique_ptr<unwindert> &_ssa_unwinder,
     ssa_inlinert &_ssa_inliner):
     options(_options),
     summary_db(_summary_db),
@@ -60,7 +60,7 @@ public:
   optionst &options;
   summary_dbt &summary_db;
   ssa_dbt &ssa_db;
-  ssa_unwindert &ssa_unwinder;
+  std::unique_ptr<unwindert> &ssa_unwinder;
   ssa_inlinert &ssa_inliner;
 
   virtual void compute_summary_rec(

--- a/src/solver/summarizer_bw.cpp
+++ b/src/solver/summarizer_bw.cpp
@@ -123,7 +123,7 @@ void summarizer_bwt::do_summary(
   solver.set_message_handler(get_message_handler());
 
   template_generator_summaryt template_generator(
-    options, ssa_db, ssa_unwinder.get(function_name));
+    options, ssa_db, ssa_unwinder->get(function_name));
   template_generator.set_message_handler(get_message_handler());
   template_generator(solver.next_domain_number(), SSA, false);
 
@@ -394,7 +394,7 @@ exprt summarizer_bwt::compute_calling_context2(
   analyzer.set_message_handler(get_message_handler());
 
   template_generator_callingcontextt template_generator(
-    options, ssa_db, ssa_unwinder.get(function_name));
+    options, ssa_db, ssa_unwinder->get(function_name));
   template_generator.set_message_handler(get_message_handler());
   template_generator(solver.next_domain_number(), SSA, n_it, f_it, false);
 

--- a/src/solver/summarizer_bw.h
+++ b/src/solver/summarizer_bw.h
@@ -16,7 +16,7 @@ Author: Peter Schrammel
 #include <util/options.h>
 
 #include <ssa/ssa_inliner.h>
-#include <ssa/ssa_unwinder.h>
+#include <ssa/unwinder.h>
 #include <ssa/local_ssa.h>
 #include <ssa/ssa_db.h>
 
@@ -29,7 +29,7 @@ public:
     optionst &options,
     summary_dbt &summary_db,
     ssa_dbt &ssa_db,
-    ssa_unwindert &ssa_unwinder,
+    std::unique_ptr<unwindert> &ssa_unwinder,
     ssa_inlinert &ssa_inliner):
     summarizer_baset(options, summary_db, ssa_db, ssa_unwinder, ssa_inliner)
   {

--- a/src/solver/summarizer_bw_term.cpp
+++ b/src/solver/summarizer_bw_term.cpp
@@ -131,13 +131,13 @@ void summarizer_bw_termt::do_summary_term(
 
   // templates for ranking functions
   template_generator_rankingt template_generator1(
-    options, ssa_db, ssa_unwinder.get(function_name));
+    options, ssa_db, ssa_unwinder->get(function_name));
   template_generator1.set_message_handler(get_message_handler());
   template_generator1(solver.next_domain_number(), SSA, true);
 
   // templates for backward summary
   template_generator_summaryt template_generator2(
-    options, ssa_db, ssa_unwinder.get(function_name));
+    options, ssa_db, ssa_unwinder->get(function_name));
   template_generator2.set_message_handler(get_message_handler());
   template_generator2(solver.next_domain_number(), SSA, false);
 

--- a/src/solver/summarizer_bw_term.h
+++ b/src/solver/summarizer_bw_term.h
@@ -16,7 +16,7 @@ Author: Peter Schrammel
 #include <util/options.h>
 
 #include <ssa/ssa_inliner.h>
-#include <ssa/ssa_unwinder.h>
+#include <ssa/unwinder.h>
 #include <ssa/local_ssa.h>
 #include <ssa/ssa_db.h>
 #include <domains/template_generator_summary.h>
@@ -31,7 +31,7 @@ public:
     optionst &_options,
     summary_dbt &_summary_db,
     ssa_dbt &_ssa_db,
-    ssa_unwindert &_ssa_unwinder,
+    std::unique_ptr<unwindert> &_ssa_unwinder,
     ssa_inlinert &_ssa_inliner):
     summarizer_bwt(_options, _summary_db, _ssa_db, _ssa_unwinder, _ssa_inliner)
   {

--- a/src/solver/summarizer_fw.cpp
+++ b/src/solver/summarizer_fw.cpp
@@ -106,7 +106,7 @@ void summarizer_fwt::do_summary(
   analyzer.set_message_handler(get_message_handler());
 
   template_generator_summaryt template_generator(
-    options, ssa_db, ssa_unwinder.get(function_name));
+    options, ssa_db, ssa_unwinder->get(function_name));
   template_generator.set_message_handler(get_message_handler());
   template_generator(solver.next_domain_number(), SSA, true);
 
@@ -120,7 +120,7 @@ void summarizer_fwt::do_summary(
   if(summary_db.exists(function_name)) // reuse existing invariants
   {
     const exprt &old_inv=summary_db.get(function_name).fw_invariant;
-    exprt inv=ssa_unwinder.get(function_name).rename_invariant(old_inv);
+    exprt inv=ssa_unwinder->get(function_name).rename_invariant(old_inv);
     conds.push_back(inv);
 
 #if 0

--- a/src/solver/summarizer_fw.h
+++ b/src/solver/summarizer_fw.h
@@ -16,7 +16,7 @@ Author: Peter Schrammel
 #include <util/options.h>
 
 #include <ssa/ssa_inliner.h>
-#include <ssa/ssa_unwinder.h>
+#include <ssa/unwinder.h>
 #include <ssa/local_ssa.h>
 #include <ssa/ssa_db.h>
 
@@ -29,7 +29,7 @@ public:
     optionst &options,
     summary_dbt &summary_db,
     ssa_dbt &ssa_db,
-    ssa_unwindert &ssa_unwinder,
+    std::unique_ptr<unwindert> &ssa_unwinder,
     ssa_inlinert &ssa_inliner):
     summarizer_baset(options, summary_db, ssa_db, ssa_unwinder, ssa_inliner)
   {

--- a/src/solver/summarizer_fw_contexts.h
+++ b/src/solver/summarizer_fw_contexts.h
@@ -17,7 +17,7 @@ Author: Peter Schrammel
 #include <util/ui_message.h>
 
 #include <ssa/ssa_inliner.h>
-#include <ssa/ssa_unwinder.h>
+#include <ssa/unwinder.h>
 #include <ssa/local_ssa.h>
 #include <ssa/ssa_db.h>
 
@@ -31,7 +31,7 @@ public:
     optionst &_options,
     summary_dbt &_summary_db,
     ssa_dbt &_ssa_db,
-    ssa_unwindert &_ssa_unwinder,
+    std::unique_ptr<unwindert> &_ssa_unwinder,
     ssa_inlinert &_ssa_inliner):
     summarizer_fwt(_options, _summary_db, _ssa_db, _ssa_unwinder, _ssa_inliner),
     ui(ui_message_handlert::uit::PLAIN)

--- a/src/solver/summarizer_fw_term.cpp
+++ b/src/solver/summarizer_fw_term.cpp
@@ -250,7 +250,7 @@ void summarizer_fw_termt::do_termination(
   solver.set_message_handler(get_message_handler());
 
   template_generator_rankingt template_generator1(
-    options, ssa_db, ssa_unwinder.get(function_name));
+    options, ssa_db, ssa_unwinder->get(function_name));
   template_generator1.set_message_handler(get_message_handler());
   template_generator1(solver.next_domain_number(), SSA, true);
 

--- a/src/solver/summarizer_fw_term.h
+++ b/src/solver/summarizer_fw_term.h
@@ -16,7 +16,7 @@ Author: Peter Schrammel
 #include <util/options.h>
 
 #include <ssa/ssa_inliner.h>
-#include <ssa/ssa_unwinder.h>
+#include <ssa/unwinder.h>
 #include <ssa/local_ssa.h>
 #include <ssa/ssa_db.h>
 
@@ -29,7 +29,7 @@ public:
     optionst &_options,
     summary_dbt &_summary_db,
     ssa_dbt &_ssa_db,
-    ssa_unwindert &_ssa_unwinder,
+    std::unique_ptr<unwindert> &_ssa_unwinder,
     ssa_inlinert &_ssa_inliner):
     summarizer_fwt(_options, _summary_db, _ssa_db, _ssa_unwinder, _ssa_inliner)
   {

--- a/src/ssa/Makefile
+++ b/src/ssa/Makefile
@@ -6,7 +6,7 @@ SRC = local_ssa.cpp ssa_var_collector.cpp \
       ssa_build_goto_trace.cpp ssa_inliner.cpp ssa_unwinder.cpp \
       unwindable_local_ssa.cpp ssa_db.cpp \
       ssa_pointed_objects.cpp  may_alias_analysis.cpp \
-      dynobj_instance_analysis.cpp
+      dynobj_instance_analysis.cpp goto_unwinder.cpp
 
 include ../config.inc
 include $(CPROVER_DIR)/src/config.inc

--- a/src/ssa/goto_unwinder.cpp
+++ b/src/ssa/goto_unwinder.cpp
@@ -1,0 +1,68 @@
+/*******************************************************************\
+Module: SSA Unwinder
+Author: František Nečas
+\*******************************************************************/
+
+/// \file
+/// SSA Unwinder
+
+#include "simplify_ssa.h"
+#include "goto_unwinder.h"
+
+void goto_local_unwindert::unwind(unsigned int k)
+{
+}
+
+/// No-op, no special initialization is necessary in this unwinder.
+void goto_local_unwindert::init()
+{
+}
+
+/// No-op, the continuation of loops is not special in any way in this unwinder,
+/// the code using this method collects the guard and condition of the loop
+/// on its own.
+void goto_local_unwindert::loop_continuation_conditions(
+  exprt::operandst &loop_cont) const
+{
+}
+
+/// No-op, since we recompute the SSA every time, the indices of SSA nodes
+/// change and the naming scheme from ssa_unwindert is not applicable.
+/// The lack of support for this makes nontermination not work with this
+/// unwinder.
+void goto_local_unwindert::unwinder_rename(
+  symbol_exprt &var,
+  const local_SSAt::nodet &node,
+  bool pre) const
+{
+}
+
+void goto_unwindert::unwind_all(unsigned int k)
+{
+  assert(is_initialized);
+
+  for (auto &local_unwinder : unwinder_map)
+    local_unwinder.second.unwind(k);
+}
+
+void goto_unwindert::init(unwinder_modet mode)
+{
+  for(auto &f : ssa_db.functions())
+  {
+    unwinder_map.insert(
+      {
+        f.first,
+        goto_local_unwindert(
+          ssa_db,
+          goto_model.goto_functions.function_map.at(f.first),
+          mode,
+          simplify)});
+  }
+}
+
+void goto_unwindert::init_localunwinders()
+{
+  for(auto &local_unwinder : unwinder_map)
+    local_unwinder.second.init();
+  is_initialized=true;
+}

--- a/src/ssa/goto_unwinder.cpp
+++ b/src/ssa/goto_unwinder.cpp
@@ -6,11 +6,172 @@ Author: František Nečas
 /// \file
 /// SSA Unwinder
 
+#include<stack>
+
+#include <goto-programs/remove_skip.h>
+#include <goto-instrument/unwindset.h>
+#include <goto-instrument/unwind.h>
+
 #include "simplify_ssa.h"
 #include "goto_unwinder.h"
 
+/// Puts all unwindings corresponding to a loop into the loop itself.
+/// This is done by changing the backwards goto target to the first instruction
+/// of the outer-most unwind.
+///
+/// Such transformation is necessary for k-induction and BMC to work properly
+/// and be able to prove correctness.
+///
+/// \note The initial state is saved so that it can be later restored.
+///   This is necessary for goto_unwindt to work correctly.
+void goto_local_unwindert::reconnect_loops()
+{
+  std::stack<goto_programt::targett> unwind_starts;
+  for(auto i_it=goto_function.body.instructions.begin();
+      i_it!=goto_function.body.instructions.end(); i_it++)
+  {
+    if(current_unwinding-i_it->get_code().get_int(unwind_flag)==0)
+    {
+      unwind_starts.push(i_it);
+    }
+    if(i_it->is_backwards_goto() && !unwind_starts.empty())
+    {
+      loop_targets[i_it->location_number]=i_it->get_target();
+      i_it->set_target(unwind_starts.top());
+      unwind_starts.pop();
+    }
+  }
+}
+
+/// Resets loop connections to the initial state which was valid before calling
+/// \ref reconnect_loops.
+/// \pre \ref reconnect_loops has been previously called, resulting in
+///   \ref loop_targets map to be filled with loop configuration.
+void goto_local_unwindert::reset_loop_connections()
+{
+  for(auto &i_it : goto_function.body.instructions)
+    if(i_it.is_backwards_goto())
+      i_it.set_target(loop_targets[i_it.location_number]);
+  loop_targets.clear();
+}
+
+/// Marks the newly produced unwinds using an integer flag to ease
+/// processing later.
+/// \param before_unwind: GOTO iterator pointing before the first new unwind.
+/// \param iteration_points: Iteration points as returned by goto_unwindt,
+///   these mark the end of each newly produced unwind.
+/// \param to_unwind: How many unwindings have been made (=the size of
+///   iteration_points).
+void goto_local_unwindert::mark_unwinds(
+  const goto_programt::targett before_unwind,
+  const std::vector<goto_programt::targett> &iteration_points,
+  unsigned to_unwind)
+{
+  auto i_it=before_unwind;
+  i_it++;
+  // Start of the outermost unwind
+  i_it->code_nonconst().set(unwind_flag, to_unwind);
+  unsigned iteration_point=0;
+  while(iteration_point<iteration_points.size())
+  {
+    if(i_it==iteration_points[iteration_point])
+    {
+      // Each iteration_point points to the last unwinding instruction
+      i_it++;
+      // We need to reverse the order of unwind numbers (mark the outermost
+      // with the highest number).
+      i_it->code_nonconst().set(unwind_flag, to_unwind-1-iteration_point);
+      iteration_point++;
+    }
+    i_it++;
+  }
+}
+
+/// Unwinds a single function up to the given bound.
+/// \param to_unwind: How many more unwindings need to be made.
+/// \note Since unwinding influences where the begin and end iterators point
+///   to and we want to consistently mark the unwinds, we keep an iterator
+///   in front of the loop (this will remain valid after unwinding).
+/// \note Because GOTO unwind adds new iterations on top of the loop,
+///   we need to increment the indexes (set as flags) of the already existing
+///   unwindings as we go.
+void goto_local_unwindert::unwind_function(
+  unsigned int to_unwind)
+{
+  goto_unwindt unwind;
+  for(auto i_it=goto_function.body.instructions.begin();
+      i_it!=goto_function.body.instructions.end();)
+  {
+    // The new unwinds will be inserted between the existing ones and the
+    // loop, update the existing unwind flags.
+    int unwind_flag_value=i_it->get_code().get_int(unwind_flag);
+    if(unwind_flag_value>0)
+      i_it->code_nonconst().set(unwind_flag, unwind_flag_value+to_unwind);
+    if(!i_it->is_backwards_goto())
+    {
+      i_it++;
+      continue;
+    }
+    goto_programt::targett loop_head=i_it->get_target();
+    auto loop_exit=i_it;
+    loop_exit++;
+
+    // Keep track of the first instruction before the unwind, we need to
+    // process the whole block later
+    auto before_unwind=loop_head;
+    before_unwind--;
+
+    // Keep loops by using CONTINUE strategy, collect iteration points
+    // (end of unwinds)
+    std::vector<goto_programt::targett> iteration_points;
+    unwind.unwind(
+      function_name,
+      goto_function.body,
+      loop_head,
+      loop_exit,
+      to_unwind,
+      goto_unwindt::unwind_strategyt::CONTINUE,
+      iteration_points);
+    mark_unwinds(before_unwind, iteration_points, to_unwind);
+    i_it=loop_exit;
+  }
+}
+
+/// Unwinds the program up to the given unwinding limit in the set mode.
+/// \param k: The target unwind count which should be present
+///   after unwinding the loop. In the case of k-induction and BMC modes,
+///   must be higher by 1 than the current unwinding. Does nothing
+///   if the current unwinding is higher than the requested one.
 void goto_local_unwindert::unwind(unsigned int k)
 {
+  if(k<=current_unwinding)
+    return;
+
+  unsigned to_unwind=k-current_unwinding;
+  debug() << "Adding " << to_unwind << " more unwindings" << messaget::eom;
+  assert(mode==unwinder_modet::NORMAL || to_unwind==1);
+
+  if(!loop_targets.empty())
+    reset_loop_connections();
+
+  // Remove skips, there may be skips made by do-while loops which would
+  // make the following loop inconsistent
+  remove_skip(goto_function.body);
+
+  if (!goto_function.body_available())
+    return;
+  unwind_function(to_unwind);
+
+  // The unwinding generated new skips and GOTOs, update
+  remove_skip(goto_function.body);
+  // The update goes a bit against the concept of this class (which should
+  // focus only on the one function, however there doesn't seem to be a better
+  // way to support the new and the old unwinder).
+  goto_functions.update();
+  current_unwinding=k;
+
+  reconnect_loops();
+  goto_functions.update();
 }
 
 /// No-op, no special initialization is necessary in this unwinder.
@@ -54,6 +215,8 @@ void goto_unwindert::init(unwinder_modet mode)
         f.first,
         goto_local_unwindert(
           ssa_db,
+          goto_model.goto_functions,
+          f.first,
           goto_model.goto_functions.function_map.at(f.first),
           mode,
           simplify)});

--- a/src/ssa/goto_unwinder.cpp
+++ b/src/ssa/goto_unwinder.cpp
@@ -289,6 +289,9 @@ void goto_local_unwindert::unwind(unsigned int k)
   current_unwinding=k;
 
   rename_dynamic_objects();
+  split_memory_leak_assignments(goto_function.body, goto_model.symbol_table);
+  goto_model.goto_functions.update();
+
   reconnect_loops();
   goto_model.goto_functions.update();
   recompute_ssa();

--- a/src/ssa/goto_unwinder.cpp
+++ b/src/ssa/goto_unwinder.cpp
@@ -148,6 +148,8 @@ void goto_local_unwindert::unwind(unsigned int k)
 {
   if(k<=current_unwinding)
     return;
+  if(!goto_function.body_available())
+    return;
 
   unsigned to_unwind=k-current_unwinding;
   debug() << "Adding " << to_unwind << " more unwindings" << messaget::eom;
@@ -159,9 +161,6 @@ void goto_local_unwindert::unwind(unsigned int k)
   // Remove skips, there may be skips made by do-while loops which would
   // make the following loop inconsistent
   remove_skip(goto_function.body);
-
-  if (!goto_function.body_available())
-    return;
   unwind_function(to_unwind);
 
   // The unwinding generated new skips and GOTOs, update
@@ -377,7 +376,7 @@ void goto_unwindert::unwind_all(unsigned int k)
 
 void goto_unwindert::init(unwinder_modet mode)
 {
-  for(auto &f : ssa_db.functions())
+  for(auto &f : goto_model.goto_functions.function_map)
   {
     unwinder_map.insert(
       {

--- a/src/ssa/goto_unwinder.cpp
+++ b/src/ssa/goto_unwinder.cpp
@@ -37,7 +37,7 @@ void goto_local_unwindert::reconnect_loops()
     }
     if(i_it->is_backwards_goto() && !unwind_starts.empty())
     {
-      loop_targets[i_it->location_number]=i_it->get_target();
+      loop_targets[i_it]=i_it->get_target();
       i_it->set_target(unwind_starts.top());
       unwind_starts.pop();
     }
@@ -50,9 +50,10 @@ void goto_local_unwindert::reconnect_loops()
 ///   \ref loop_targets map to be filled with loop configuration.
 void goto_local_unwindert::reset_loop_connections()
 {
-  for(auto &i_it : goto_function.body.instructions)
-    if(i_it.is_backwards_goto())
-      i_it.set_target(loop_targets[i_it.location_number]);
+  for(auto i_it=goto_function.body.instructions.begin();
+      i_it!=goto_function.body.instructions.end(); i_it++)
+    if(i_it->is_backwards_goto() && loop_targets.find(i_it)!=loop_targets.end())
+      i_it->set_target(loop_targets.at(i_it));
   loop_targets.clear();
 }
 

--- a/src/ssa/goto_unwinder.cpp
+++ b/src/ssa/goto_unwinder.cpp
@@ -332,10 +332,17 @@ void goto_local_unwindert::add_hoisted_assertions(
 /// Performs necessary transformations to the SSA.
 /// \param SSA: The SSA that is being processed.
 /// \param goto_program: The GOTO program corresponding to the given SSA.
+///
+/// \note This is no-op if the program contains dynamic memory since by
+///   unwinding, we introduce new dynamic objects which possibly changes the
+///   semantic of the unwound assertion which goes against the concept of
+///   SSA constraints.
 void goto_local_unwindert::update_ssa(
   local_SSAt &SSA,
   const goto_programt &goto_program)
 {
+  if(dynamic_memory)
+    return;
   add_hoisted_assertions(SSA, goto_program);
   update_assertions(SSA, goto_program);
 }
@@ -387,7 +394,8 @@ void goto_unwindert::init(unwinder_modet mode)
           f.first,
           goto_model.goto_functions.function_map.at(f.first),
           mode,
-          simplify)});
+          simplify,
+          dynamic_memory)});
   }
 }
 

--- a/src/ssa/goto_unwinder.h
+++ b/src/ssa/goto_unwinder.h
@@ -29,10 +29,14 @@ class goto_local_unwindert:public local_unwindert, messaget
 public:
   goto_local_unwindert(
     ssa_dbt &_ssa_db,
+    goto_functionst &_goto_functions,
+    const irep_idt &_function_name,
     goto_functiont &_goto_function,
     unwinder_modet _mode,
     bool _simplify):
     ssa_db(_ssa_db),
+    goto_functions(_goto_functions),
+    function_name(_function_name),
     goto_function(_goto_function),
     mode(_mode),
     simplify(_simplify)
@@ -49,14 +53,32 @@ public:
     bool pre) const override;
 
 protected:
+  /// A flag which is used for marking unwind starts inside the GOTO program.
+  const irep_idt unwind_flag="unwind";
   /// Reference to a global storage of SSA.
   ssa_dbt &ssa_db;
+  /// All functions in the GOTO model. Required for calling update()
+  goto_functionst &goto_functions;
+  /// Name of the function to unwind.
+  const irep_idt &function_name;
   /// The GOTO function which this unwinder unwinds.
   goto_functiont &goto_function;
   /// Mode under which the unwinder operates.
   unwinder_modet mode;
   /// Whether the unwound SSA should be simplified.
   bool simplify;
+  /// A store used for keeping track of how loops were formerly connected
+  /// before transformations required for k-induction or BMC to correctly
+  /// work were done.
+  std::unordered_map<unsigned, goto_programt::targett> loop_targets;
+
+  void unwind_function(unsigned to_unwind);
+  void mark_unwinds(
+    const goto_programt::targett before_unwind,
+    const std::vector<goto_programt::targett> &iteration_points,
+    unsigned to_unwind);
+  void reconnect_loops();
+  void reset_loop_connections();
 };
 
 

--- a/src/ssa/goto_unwinder.h
+++ b/src/ssa/goto_unwinder.h
@@ -71,7 +71,7 @@ protected:
   /// A store used for keeping track of how loops were formerly connected
   /// before transformations required for k-induction or BMC to correctly
   /// work were done.
-  std::unordered_map<unsigned, goto_programt::targett> loop_targets;
+  std::map<goto_programt::targett, goto_programt::targett> loop_targets;
 
   void unwind_function(unsigned to_unwind);
   void mark_unwinds(

--- a/src/ssa/goto_unwinder.h
+++ b/src/ssa/goto_unwinder.h
@@ -33,13 +33,15 @@ public:
     const irep_idt &_function_name,
     goto_functiont &_goto_function,
     unwinder_modet _mode,
-    bool _simplify):
+    bool _simplify,
+    bool _dynamic_memory):
     ssa_db(_ssa_db),
     goto_model(_goto_model),
     function_name(_function_name),
     goto_function(_goto_function),
     mode(_mode),
-    simplify(_simplify)
+    simplify(_simplify),
+    dynamic_memory(_dynamic_memory)
   {
   }
 
@@ -68,6 +70,8 @@ protected:
   unwinder_modet mode;
   /// Whether the unwound SSA should be simplified.
   bool simplify;
+  /// Whether dynamic memory is present in the program
+  bool dynamic_memory;
   /// A store used for keeping track of how loops were formerly connected
   /// before transformations required for k-induction or BMC to correctly
   /// work were done.
@@ -106,10 +110,12 @@ public:
   explicit goto_unwindert(
     ssa_dbt &_ssa_db,
     goto_modelt &_goto_model,
-    bool _simplify) :
+    bool _simplify,
+    bool _dynamic_memory) :
     ssa_db(_ssa_db),
     goto_model(_goto_model),
     simplify(_simplify),
+    dynamic_memory(_dynamic_memory),
     is_initialized(false)
   {}
 
@@ -137,6 +143,8 @@ protected:
   goto_modelt &goto_model;
   /// Whether the unwound SSA should be simplified.
   bool simplify;
+  /// Whether dynamic memory is present in the program
+  bool dynamic_memory;
   /// Whether the unwinder is fully initialized.
   bool is_initialized;
   /// Maps function names to their respective local unwinders.

--- a/src/ssa/goto_unwinder.h
+++ b/src/ssa/goto_unwinder.h
@@ -82,6 +82,12 @@ protected:
     const goto_programt::targett before_unwind,
     const std::vector<goto_programt::targett> &iteration_points,
     unsigned to_unwind);
+  void delete_dynamic_objects_from_symtable();
+  void rename_dynamic_objects_rec(
+    goto_programt::instructiont &it,
+    exprt &expr,
+    std::map<std::string, std::string> &rename_map);
+  void rename_dynamic_objects();
   void reconnect_loops();
   void reset_loop_connections();
   void recompute_ssa();

--- a/src/ssa/goto_unwinder.h
+++ b/src/ssa/goto_unwinder.h
@@ -1,0 +1,108 @@
+/*******************************************************************\
+Module: SSA Unwinder
+Author: František Nečas
+\*******************************************************************/
+
+/// \file
+/// SSA Unwinder that unwinds the SSA by unwinding the given GOTO
+/// program and converting the unwound program back to SSA rather
+/// than unwinding on the SSA level. This enables 2LS to unwind
+/// loops which create dynamic objects (points-to analysis
+/// is kept in sync with the actual state of dynamic objects).
+///
+/// The current implementation doesn't utilise incremental SAT solving
+/// correctly so its performance is hindered, however it produces more
+/// sound results in the case of programs with dynamic memory.
+/// Moreover due to the current implementation of summary_checker_nonterm,
+/// (relying on renames based on % suffixes), nontermination support
+/// is not possible in this type of implementation.
+
+#ifndef CPROVER_2LS_SSA_GOTO_UNWINDER_H
+#define CPROVER_2LS_SSA_GOTO_UNWINDER_H
+
+#include "unwindable_local_ssa.h"
+#include "unwinder.h"
+#include "ssa_db.h"
+
+class goto_local_unwindert:public local_unwindert, messaget
+{
+public:
+  goto_local_unwindert(
+    ssa_dbt &_ssa_db,
+    goto_functiont &_goto_function,
+    unwinder_modet _mode,
+    bool _simplify):
+    ssa_db(_ssa_db),
+    goto_function(_goto_function),
+    mode(_mode),
+    simplify(_simplify)
+  {
+  }
+
+  void init() override;
+  void unwind(unsigned k) override;
+
+  void loop_continuation_conditions(exprt::operandst& loop_cont) const override;
+  void unwinder_rename(
+    symbol_exprt &var,
+    const local_SSAt::nodet &node,
+    bool pre) const override;
+
+protected:
+  /// Reference to a global storage of SSA.
+  ssa_dbt &ssa_db;
+  /// The GOTO function which this unwinder unwinds.
+  goto_functiont &goto_function;
+  /// Mode under which the unwinder operates.
+  unwinder_modet mode;
+  /// Whether the unwound SSA should be simplified.
+  bool simplify;
+};
+
+
+/// An SSA unwinder that unwinds the given GOTO and then transforms
+/// the changes into SSA.
+class goto_unwindert:public unwindert, messaget
+{
+public:
+  explicit goto_unwindert(
+    ssa_dbt &_ssa_db,
+    goto_modelt &_goto_model,
+    bool _simplify) :
+    ssa_db(_ssa_db),
+    goto_model(_goto_model),
+    simplify(_simplify),
+    is_initialized(false)
+  {}
+
+  void init(unwinder_modet mode) override;
+  void init_localunwinders() override;
+
+  void unwind_all(unsigned k) override;
+
+  inline goto_local_unwindert &get(const irep_idt& fname) override
+  {
+    return unwinder_map.at(fname);
+  }
+
+  inline const goto_local_unwindert &get(const irep_idt& fname) const override
+  {
+    return unwinder_map.at(fname);
+  }
+
+protected:
+  typedef std::map<irep_idt, goto_local_unwindert> unwinder_mapt;
+
+  /// Reference to a global storage of SSA.
+  ssa_dbt &ssa_db;
+  /// Reference to a GOTO program tied to this unwinder.
+  goto_modelt &goto_model;
+  /// Whether the unwound SSA should be simplified.
+  bool simplify;
+  /// Whether the unwinder is fully initialized.
+  bool is_initialized;
+  /// Maps function names to their respective local unwinders.
+  unwinder_mapt unwinder_map;
+};
+
+#endif

--- a/src/ssa/goto_unwinder.h
+++ b/src/ssa/goto_unwinder.h
@@ -29,13 +29,13 @@ class goto_local_unwindert:public local_unwindert, messaget
 public:
   goto_local_unwindert(
     ssa_dbt &_ssa_db,
-    goto_functionst &_goto_functions,
+    goto_modelt &_goto_model,
     const irep_idt &_function_name,
     goto_functiont &_goto_function,
     unwinder_modet _mode,
     bool _simplify):
     ssa_db(_ssa_db),
-    goto_functions(_goto_functions),
+    goto_model(_goto_model),
     function_name(_function_name),
     goto_function(_goto_function),
     mode(_mode),
@@ -57,8 +57,9 @@ protected:
   const irep_idt unwind_flag="unwind";
   /// Reference to a global storage of SSA.
   ssa_dbt &ssa_db;
-  /// All functions in the GOTO model. Required for calling update()
-  goto_functionst &goto_functions;
+  /// The whole GOTO model. Required for calling update() and accessing the
+  /// symbol table for SSA recomputing.
+  goto_modelt &goto_model;
   /// Name of the function to unwind.
   const irep_idt &function_name;
   /// The GOTO function which this unwinder unwinds.
@@ -79,6 +80,21 @@ protected:
     unsigned to_unwind);
   void reconnect_loops();
   void reset_loop_connections();
+  void recompute_ssa();
+  void update_ssa(
+    local_SSAt &SSA,
+    const goto_programt &goto_program);
+  void update_assertions(
+    local_SSAt &SSA,
+    const goto_programt &goto_program);
+  void add_hoisted_assertions(
+    local_SSAt &SSA,
+    const goto_programt &goto_program);
+  void convert_to_constraints(
+    local_SSAt &SSA,
+    local_SSAt::nodest::iterator &ssa_it,
+    local_SSAt::nodest::iterator &loop_back,
+    bool is_last);
 };
 
 

--- a/src/ssa/local_ssa.cpp
+++ b/src/ssa/local_ssa.cpp
@@ -1611,7 +1611,7 @@ bool local_SSAt::can_reuse_symderef(
 
   // If the pointer that is dereferenced was overwritten, the symbolic deref
   // is not valid.
-  if(pointer_def.is_assignment() && pointer_def.loc->location_number>
+  if(pointer_def.is_assignment() && pointer_def.loc->location_number>=
                                     symbolic_def.loc->location_number)
     return false;
 

--- a/src/ssa/malloc_ssa.cpp
+++ b/src/ssa/malloc_ssa.cpp
@@ -21,8 +21,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <analyses/constant_propagator.h>
 
 #include <functional>
+#include <iterator>
 
 #include "malloc_ssa.h"
+#include <domains/util.h>
 
 inline static optionalt<typet> c_sizeof_type_rec(const exprt &expr)
 {
@@ -515,4 +517,186 @@ void allow_record_memleak(goto_modelt &goto_model)
       return name.find("malloc::")!=std::string::npos &&
              name.find("::record_may_leak")!=std::string::npos;
     });
+}
+
+/// Removes assignments to __CPROVER_memory_leak inside free function.
+/// These are in the form:
+///   IF !(__CPROVER_memory_leak == free::ptr) GOTO 1
+///     ASSIGN __CPROVER_memory_leak = NULL
+///   1:...
+void remove_free_memory_leak_assignments(
+  goto_programt &goto_program,
+  goto_programt::targett i_it)
+{
+  // Insert a skip and redirect incoming GOTOs, we will be removing the
+  // instructions.
+  auto skip=goto_program.insert_before(
+    i_it,
+    goto_programt::make_skip(i_it->source_location));
+  for(auto &target : i_it->incoming_edges)
+    if(target->is_goto())
+      target->set_target(skip);
+  goto_program.update();
+
+  while(i_it!=goto_program.instructions.end() &&
+        i_it->is_goto() &&
+        i_it->source_location.get_function()=="free")
+  {
+    auto next=std::next(i_it, 1);
+    if (next==goto_program.instructions.end() || !next->is_assign())
+      return;
+    auto &symb_expr=to_symbol_expr(next->assign_lhs());
+    std::string identif=symb_expr.get_identifier().c_str();
+    if (identif.find("__CPROVER_memory_leak")==std::string::npos)
+      return;
+    // Delete the ASSIGN
+    goto_program.instructions.erase(next);
+    // Delete the GOTO and move forward
+    goto_program.instructions.erase(i_it++);
+  }
+}
+
+/// Inserts assignments to __CPROVER_memory_leak symbols into the given GOTO
+/// program starting at the given location.
+/// \param goto_program GOTO program to insert into.
+/// \param i_it Starting location in the inlined free function.
+/// \param symbols Currently defined __CPROVER_memory_leak symbols
+/// \param free_ptr Symbol exprt representing the ptr being freed.
+void reinsert_free_memory_leak_assignments(
+  goto_programt &goto_program,
+  goto_programt::targett i_it,
+  const std::vector<symbolt> &symbols,
+  const symbol_exprt &free_ptr)
+{
+  auto jump_target=i_it;
+  jump_target++;
+  for(const auto &symbol : symbols)
+  {
+    auto goto_it=goto_program.insert_after(
+      i_it,
+      goto_programt::make_goto(
+        jump_target,
+        not_exprt(
+          equal_exprt(
+            symbol_exprt(symbol.name, symbol.type),
+            free_ptr)),
+        i_it->source_location));
+    goto_program.insert_after(
+      goto_it,
+      goto_programt::make_assignment(
+        symbol_exprt(symbol.name, symbol.type),
+        null_pointer_exprt(
+          to_pointer_type(symbol.type)),
+        i_it->source_location));
+    jump_target=goto_it;
+  }
+}
+
+/// Checks whether the expression uses __CPROVER_memory_leak symbol
+bool uses_memory_leak_symbol(const exprt &expr)
+{
+  if(expr.id()==ID_symbol)
+  {
+    const auto &symbol_expr=to_symbol_expr(expr);
+    std::string identif=symbol_expr.get_identifier().c_str();
+    if(identif.find("__CPROVER_memory_leak")!=std::string::npos)
+      return true;
+  }
+  else
+    for(const auto &op : expr.operands())
+      if(uses_memory_leak_symbol(op))
+        return true;
+  return false;
+}
+
+/// Splits assignments to CPROVER_memory_leak variables to allow for
+/// sound memory leak analysis of programs with multiple malloc calls
+/// (e.g. after unwinding).
+/// \pre malloc has been inlined.
+void split_memory_leak_assignments(goto_programt &goto_program, symbol_tablet &symbol_table)
+{
+  symbolt leak_symbol=*symbol_table.lookup("__CPROVER_memory_leak");
+  std::string base=leak_symbol.base_name.c_str();
+  std::vector<symbolt> defined_symbols;
+  Forall_goto_program_instructions(i_it, goto_program)
+  {
+    if(i_it->is_assign())
+    {
+      if(i_it->assign_lhs().id()!=ID_symbol)
+        continue;
+      auto &symbol_expr=to_symbol_expr(i_it->assign_lhs_nonconst());
+      std::string identif=symbol_expr.get_identifier().c_str();
+      if(identif.find(base)==std::string::npos)
+        continue;
+      if(i_it->source_location.get_function()=="malloc")
+      {
+        // Replace the assignment inside malloc
+        symbolt new_symbol=leak_symbol;
+        std::string name=base+"$"+std::to_string(i_it->location_number);
+        new_symbol.name=name;
+        new_symbol.base_name=name;
+        symbol_table.add(new_symbol);
+        symbol_expr.set_identifier(new_symbol.name);
+        replace_symbol(
+          i_it->assign_rhs_nonconst(),
+          identif,
+          new_symbol.name);
+        defined_symbols.push_back(new_symbol);
+      }
+      else if(i_it->source_location.get_function()!="free")
+      {
+        // Remove initialization, we will insert it again.
+        goto_program.instructions.erase(i_it++);
+        i_it--;
+      }
+    }
+    else if(i_it->is_goto() && i_it->source_location.get_function()=="free")
+    {
+      // Replace setting to null in free, add all the newly defined symbols
+      auto next=std::next(i_it, 1);
+      if(next==goto_program.instructions.end() ||
+         !next->is_assign() || next->assign_lhs().id()!=ID_symbol)
+        continue;
+      std::string next_id=to_symbol_expr(
+        next->assign_lhs()).get_identifier().c_str();
+      if(next_id.find(base)==std::string::npos)
+        continue;
+      // The goto is in the form IF !(memory_leak = free::ptr) GOTO
+      symbol_exprt ptr=to_symbol_expr(
+        to_equal_expr(to_not_expr(i_it->get_condition()).op()).op1());
+      auto prev=i_it;
+      prev--;
+      remove_free_memory_leak_assignments(goto_program, i_it);
+      i_it=prev;
+      i_it++;
+      auto continue_it=i_it;
+      continue_it++;
+      reinsert_free_memory_leak_assignments(
+        goto_program,
+        i_it,
+        defined_symbols,
+        ptr);
+      // Jump over the inserted stuff, move back one, the loop will i_it++
+      i_it=continue_it;
+      i_it--;
+    }
+    else if((i_it->is_assert() || i_it->is_assume()) &&
+            uses_memory_leak_symbol(i_it->get_condition()))
+    {
+      exprt::operandst equalities;
+      for(const auto &symbol : defined_symbols)
+        equalities.push_back(
+          equal_exprt(
+            symbol_exprt(symbol.name, symbol.type),
+            null_pointer_exprt(to_pointer_type(symbol.type))));
+      i_it->set_condition(conjunction(equalities));
+    }
+  }
+  // Insert new initializations
+  for(const auto &symbol : defined_symbols)
+    goto_program.insert_before(
+      goto_program.instructions.begin(),
+      goto_programt::make_assignment(
+        symbol_exprt(symbol.name, symbol.type),
+        null_pointer_exprt(to_pointer_type(symbol.type))));
 }

--- a/src/ssa/malloc_ssa.h
+++ b/src/ssa/malloc_ssa.h
@@ -41,5 +41,8 @@ std::vector<exprt> collect_pointer_vars(
 
 void allow_record_malloc(goto_modelt &goto_model);
 void allow_record_memleak(goto_modelt &goto_model);
+void split_memory_leak_assignments(
+  goto_programt &goto_program,
+  symbol_tablet &symbol_table);
 
 #endif

--- a/src/ssa/malloc_ssa.h
+++ b/src/ssa/malloc_ssa.h
@@ -19,6 +19,8 @@ exprt malloc_ssa(
   const side_effect_exprt &,
   const std::string &suffix,
   symbol_tablet &,
+  goto_programt &,
+  goto_programt::targett &,
   bool is_concrete,
   bool alloc_concrete);
 

--- a/src/ssa/malloc_ssa.h
+++ b/src/ssa/malloc_ssa.h
@@ -29,6 +29,16 @@ bool replace_malloc(
   const std::string &suffix,
   bool alloc_concrete);
 
+exprt create_dynamic_object(
+  const std::string &suffix,
+  const typet &type,
+  symbol_tablet &symbol_table,
+  bool is_concrete);
+
+std::vector<exprt> collect_pointer_vars(
+  const symbol_tablet &symbol_table,
+  const typet &pointed_type);
+
 void allow_record_malloc(goto_modelt &goto_model);
 void allow_record_memleak(goto_modelt &goto_model);
 

--- a/src/ssa/ssa_db.h
+++ b/src/ssa/ssa_db.h
@@ -65,11 +65,24 @@ public:
     return store.find(function_name)!=store.end();
   }
 
+  inline void clear_solver(const function_namet &function_name)
+  {
+    solverst::iterator it=the_solvers.find(function_name);
+    if(it!=the_solvers.end())
+    {
+      delete it->second;
+      the_solvers.erase(it);
+    }
+  }
+
   inline void create(
     const function_namet &function_name,
     const goto_functionst::goto_functiont &goto_function,
     const symbol_tablet &symbol_table)
   {
+    // Avoid memory leaks if overriding
+    if(store.count(function_name))
+      delete store[function_name];
     store[function_name]=
       new unwindable_local_SSAt(
         function_name,

--- a/src/ssa/ssa_unwinder.cpp
+++ b/src/ssa/ssa_unwinder.cpp
@@ -382,11 +382,11 @@ void ssa_local_unwindert::add_assertions(loopt &loop, bool is_last)
       SSA.rename(*a_it, node.location);
       if(!is_last) // only add assumptions if we are not in %0 iteration
       {
-        if(is_kinduction)
+        if(mode==unwinder_modet::K_INDUCTION)
         {
           node.constraints.push_back(*a_it);
         }
-        else if(is_bmc)
+        else if(mode==unwinder_modet::BMC)
         {
           // only add in base case
           exprt gs=
@@ -398,7 +398,7 @@ void ssa_local_unwindert::add_assertions(loopt &loop, bool is_last)
         }
       }
     }
-    if(!is_last && (is_bmc || is_kinduction))
+    if(!is_last && mode!=unwinder_modet::NORMAL)
     {
       node.assertions.clear();
     }
@@ -545,7 +545,7 @@ void ssa_local_unwindert::add_hoisted_assertions(loopt &loop, bool is_last)
       it!=loop.assertion_hoisting_map.end(); ++it)
   {
     if(!is_last // only add assumptions if we are not in %0 iteration
-       && is_kinduction && !it->second.assertions.empty()
+       && mode==unwinder_modet::K_INDUCTION && !it->second.assertions.empty()
 #ifdef COMPETITION
        && !has_overflow_shl(it->first->guard))
 #endif
@@ -665,7 +665,7 @@ void ssa_unwindert::unwind_all(unsigned int k)
 /// Initialize unwinder_map by computing hierarchical tree_loopnodet for every
 /// goto-function Set is_initialized to true. Initializer must be called before
 /// unwind funcitions are called.
-void ssa_unwindert::init(bool is_kinduction, bool is_bmc)
+void ssa_unwindert::init(unwinder_modet mode)
 {
   ssa_dbt::functionst& funcs=ssa_db.functions();
   for(auto &f : funcs)
@@ -673,7 +673,7 @@ void ssa_unwindert::init(bool is_kinduction, bool is_bmc)
     unwinder_map.insert(
       unwinder_pairt(
         f.first,
-        ssa_local_unwindert(f.first, (*(f.second)), is_kinduction, is_bmc)));
+        ssa_local_unwindert(f.first, (*(f.second)), mode)));
   }
 }
 

--- a/src/ssa/ssa_unwinder.cpp
+++ b/src/ssa/ssa_unwinder.cpp
@@ -654,19 +654,6 @@ void ssa_local_unwindert::unwinder_rename(
 #endif
 }
 
-/// incrementally unwind a function 'id' up to depth k. Initializer must have
-/// been invoked before calling this function
-/// \param fname:name of the goto-function to be unwound, k-unwinding depth
-/// \return false-if id does not correspond to any goto-function in the
-///   unwinder_map
-void ssa_unwindert::unwind(const irep_idt fname, unsigned int k)
-{
-  assert(is_initialized);
-  unwinder_mapt::iterator it=unwinder_map.find(fname);
-  assert(it!=unwinder_map.end());
-  it->second.unwind(k);
-}
-
 void ssa_unwindert::unwind_all(unsigned int k)
 {
   assert(is_initialized);

--- a/src/ssa/ssa_unwinder.cpp
+++ b/src/ssa/ssa_unwinder.cpp
@@ -667,8 +667,7 @@ void ssa_unwindert::unwind_all(unsigned int k)
 /// unwind funcitions are called.
 void ssa_unwindert::init(unwinder_modet mode)
 {
-  ssa_dbt::functionst& funcs=ssa_db.functions();
-  for(auto &f : funcs)
+  for(auto &f : ssa_db.functions())
   {
     unwinder_map.insert(
       unwinder_pairt(

--- a/src/ssa/ssa_unwinder.cpp
+++ b/src/ssa/ssa_unwinder.cpp
@@ -245,10 +245,7 @@ void ssa_local_unwindert::unwind(unsigned k)
     assert(SSA.current_unwindings.empty());
   }
   // update current unwinding
-  for(loop_mapt::iterator it=loops.begin(); it!=loops.end(); ++it)
-  {
-    it->second.current_unwinding=k;
-  }
+  current_unwinding=k;
 }
 
 /// unwind all instances of given loop up to k starting from previous
@@ -265,7 +262,7 @@ void ssa_local_unwindert::unwind(loopt &loop, unsigned k, bool is_new_parent)
   for(long i=0; i<=k; ++i)
   {
     // add new unwindings of this loop
-    if(i>loop.current_unwinding || is_new_parent)
+    if(i>current_unwinding || is_new_parent)
     {
       add_loop_body(loop);
       // set new loop end node
@@ -316,7 +313,7 @@ void ssa_local_unwindert::unwind(loopt &loop, unsigned k, bool is_new_parent)
 #ifdef DEBUG
       std::cout << i << ">" << loop.current_unwinding << std::endl;
 #endif
-      unwind(loops[l], k, i>loop.current_unwinding || is_new_parent);
+      unwind(loops[l], k, i>current_unwinding || is_new_parent);
     }
     SSA.increment_unwindings(0);
   }
@@ -597,7 +594,7 @@ void ssa_local_unwindert::loop_continuation_conditions(
 {
   SSA.increment_unwindings(1);
   loop_cont.push_back(get_continuation_condition(loop)); // %0
-  for(long i=0; i<=loop.current_unwinding; ++i)
+  for(long i=0; i<=current_unwinding; ++i)
   {
     // recurse into child loops
     for(const auto &l : loop.loop_nodes)
@@ -655,19 +652,6 @@ void ssa_local_unwindert::unwinder_rename(
 #ifdef DEBUG
   std::cout << "new id: " << var.get_identifier() << std::endl;
 #endif
-}
-
-
-bool ssa_local_unwindert::find_loop(
-  unsigned location_number, const loopt *&loop) const
-{
-  loop_mapt::const_iterator it=loops.find(location_number);
-  if(it!=loops.end())
-  {
-    loop=&it->second;
-    return true;
-  }
-  return false;
 }
 
 /// incrementally unwind a function 'id' up to depth k. Initializer must have

--- a/src/ssa/ssa_unwinder.h
+++ b/src/ssa/ssa_unwinder.h
@@ -48,6 +48,9 @@ public:
     const local_SSAt::nodet &node,
     bool pre) const;
 
+  long current_unwinding;
+
+protected:
   class loopt // loop tree
   {
   public:
@@ -78,9 +81,6 @@ public:
     assertion_hoisting_mapt assertion_hoisting_map;
   };
 
-  long current_unwinding;
-
-protected:
   const irep_idt fname;
   unwindable_local_SSAt &SSA;
   unwinder_modet mode;

--- a/src/ssa/ssa_unwinder.h
+++ b/src/ssa/ssa_unwinder.h
@@ -16,7 +16,7 @@ Author: Peter Schrammel, Saurabh Joshi
 #include "ssa_db.h"
 #include "unwinder.h"
 
-class ssa_local_unwindert
+class ssa_local_unwindert:public local_unwindert
 {
 public:
   typedef local_SSAt::locationt locationt;
@@ -26,7 +26,6 @@ public:
     const irep_idt _fname,
     unwindable_local_SSAt& _SSA,
     unwinder_modet _mode):
-    current_unwinding(-1),
     fname(_fname),
     SSA(_SSA),
     mode(_mode),
@@ -34,21 +33,18 @@ public:
   {
   }
 
-  void init();
-
-  void unwind(unsigned k);
+  void init() override;
+  void unwind(unsigned k) override;
 
   // TODO: this should be loop specific in future,
   // maybe move to unwindable_local_ssa as it is not really unwinder related
-  void loop_continuation_conditions(exprt::operandst& loop_cont) const;
+  void loop_continuation_conditions(exprt::operandst& loop_cont) const override;
 
   // TODO: this must go away, should use SSA.rename instead
   void unwinder_rename(
     symbol_exprt &var,
     const local_SSAt::nodet &node,
-    bool pre) const;
-
-  long current_unwinding;
+    bool pre) const override;
 
 protected:
   class loopt // loop tree
@@ -115,7 +111,7 @@ protected:
   void add_hoisted_assertions(loopt &loop, bool is_last);
 };
 
-class ssa_unwindert:public messaget
+class ssa_unwindert:public unwindert, public messaget
 {
 public:
   typedef std::map<irep_idt, ssa_local_unwindert> unwinder_mapt;
@@ -127,17 +123,17 @@ public:
   {
   }
 
-  void init(unwinder_modet mode);
-  void init_localunwinders();
+  void init(unwinder_modet mode) override;
+  void init_localunwinders() override;
 
-  void unwind_all(unsigned k);
+  void unwind_all(unsigned k) override;
 
-  inline ssa_local_unwindert &get(const irep_idt& fname)
+  inline ssa_local_unwindert &get(const irep_idt& fname) override
   {
     return unwinder_map.at(fname);
   }
 
-  inline const ssa_local_unwindert &get(const irep_idt& fname) const
+  inline const ssa_local_unwindert &get(const irep_idt& fname) const override
   {
     return unwinder_map.at(fname);
   }

--- a/src/ssa/ssa_unwinder.h
+++ b/src/ssa/ssa_unwinder.h
@@ -26,6 +26,7 @@ public:
     unwindable_local_SSAt& _SSA,
     bool _is_kinduction,
     bool _is_bmc):
+    current_unwinding(-1),
     fname(_fname),
     SSA(_SSA),
     is_kinduction(_is_kinduction),
@@ -70,8 +71,7 @@ public:
   public:
     loopt():
       is_dowhile(false),
-      is_root(false),
-      current_unwinding(-1)
+      is_root(false)
     {
     }
 
@@ -81,7 +81,6 @@ public:
     std::vector<unsigned> loop_nodes; // child loops
     bool is_dowhile;
     bool is_root;
-    long current_unwinding;
     typedef std::map<exprt, exprt::operandst> exit_mapt;
     exit_mapt exit_map;
     std::map<symbol_exprt, symbol_exprt> pre_post_map;
@@ -97,7 +96,7 @@ public:
     assertion_hoisting_mapt assertion_hoisting_map;
   };
 
-  bool find_loop(unsigned location_number, const loopt *&loop) const;
+  long current_unwinding;
 
 protected:
   const irep_idt fname;

--- a/src/ssa/ssa_unwinder.h
+++ b/src/ssa/ssa_unwinder.h
@@ -14,6 +14,7 @@ Author: Peter Schrammel, Saurabh Joshi
 
 #include "unwindable_local_ssa.h"
 #include "ssa_db.h"
+#include "unwinder.h"
 
 class ssa_local_unwindert
 {
@@ -24,13 +25,11 @@ public:
   ssa_local_unwindert(
     const irep_idt _fname,
     unwindable_local_SSAt& _SSA,
-    bool _is_kinduction,
-    bool _is_bmc):
+    unwinder_modet _mode):
     current_unwinding(-1),
     fname(_fname),
     SSA(_SSA),
-    is_kinduction(_is_kinduction),
-    is_bmc(_is_bmc),
+    mode(_mode),
     current_enabling_expr(bool_typet())
   {
   }
@@ -84,7 +83,7 @@ public:
 protected:
   const irep_idt fname;
   unwindable_local_SSAt &SSA;
-  bool is_kinduction, is_bmc;
+  unwinder_modet mode;
   symbol_exprt current_enabling_expr; // TODO must become loop-specific
 
   // use location numbers as indices, as target addresses make
@@ -128,7 +127,7 @@ public:
   {
   }
 
-  void init(bool is_kinduction, bool is_bmc);
+  void init(unwinder_modet mode);
   void init_localunwinders();
 
   void unwind_all(unsigned k);

--- a/src/ssa/ssa_unwinder.h
+++ b/src/ssa/ssa_unwinder.h
@@ -131,7 +131,6 @@ public:
   void init(bool is_kinduction, bool is_bmc);
   void init_localunwinders();
 
-  void unwind(const irep_idt fname, unsigned k);
   void unwind_all(unsigned k);
 
   inline ssa_local_unwindert &get(const irep_idt& fname)

--- a/src/ssa/ssa_unwinder.h
+++ b/src/ssa/ssa_unwinder.h
@@ -39,26 +39,9 @@ public:
 
   void unwind(unsigned k);
 
-#if 0
-  // TODO: not yet sure how to do that
-  void unwind(locationt loop_head_loc, unsigned k)
-  {
-    unwind(loops[loop_head_loc], k);
-  }
-#endif
-
   // TODO: this should be loop specific in future,
   // maybe move to unwindable_local_ssa as it is not really unwinder related
   void loop_continuation_conditions(exprt::operandst& loop_cont) const;
-
-#if 0
-  // TODO: these two should be possible with unwindable_local_ssa facilities
-  exprt rename_invariant(const exprt& inv_in) const;
-  void unwinder_rename(
-    symbol_exprt &var,
-    const local_SSAt::nodet &node,
-    bool pre) const;
-#endif
 
   // TODO: this must go away, should use SSA.rename instead
   void unwinder_rename(

--- a/src/ssa/ssa_var_collector.h
+++ b/src/ssa/ssa_var_collector.h
@@ -15,7 +15,7 @@ Author: Peter Schrammel, Stefan Marticek
 #include <util/options.h>
 
 #include "local_ssa.h"
-#include "ssa_unwinder.h"
+#include "unwinder.h"
 
 #include <domains/strategy_solver_base.h>
 
@@ -26,7 +26,7 @@ public:
 
   explicit ssa_var_collectort(
     optionst &_options,
-    ssa_local_unwindert &_ssa_local_unwinder):
+    local_unwindert &_ssa_local_unwinder):
     options(_options),
     ssa_local_unwinder(_ssa_local_unwinder)
   {
@@ -75,7 +75,7 @@ public:
 
 protected:
   bool std_invariants; // include value at loop entry
-  const ssa_local_unwindert &ssa_local_unwinder;
+  const local_unwindert &ssa_local_unwinder;
 };
 
 #endif // CPROVER_2LS_SSA_SSA_VAR_COLLECTOR_H

--- a/src/ssa/unwinder.h
+++ b/src/ssa/unwinder.h
@@ -12,6 +12,8 @@ Author: František Nečas
 #ifndef CPROVER_2LS_SSA_UNWINDER_H
 #define CPROVER_2LS_SSA_UNWINDER_H
 
+#include "local_ssa.h"
+
 /// Represents the mode which an unwinder operates in.
 enum class unwinder_modet
 {
@@ -23,6 +25,56 @@ enum class unwinder_modet
   /// K-induction is being performed, add constraints and also hoisted
   /// assertions.
   K_INDUCTION,
+};
+
+/// An abstract class representing an SSA unwinder of a single function.
+class local_unwindert
+{
+public:
+  /// Performs initializing actions that need to be done before the first
+  /// unwinding.
+  virtual void init()=0;
+
+  /// Performs unwinding of all loops in the function up to bound k
+  /// \param The target unwind count which should be present after
+  ///   unwinding the loop.
+  virtual void unwind(unsigned k)=0;
+
+  /// Gathers conditions under which loops continue.
+  /// \param loop_cont Store for the gathered conditions.
+  virtual void loop_continuation_conditions(
+    exprt::operandst& loop_cont) const=0;
+
+  /// Renames a variable based on the current unwinding.
+  /// \param var Variable to rename.
+  /// \param node SSA node providing context under which the rename
+  ///   should occur.
+  /// \param pre If set to false, 0-th unwind (base loop) will be considered.
+  virtual void unwinder_rename(
+    symbol_exprt &var,
+    const local_SSAt::nodet &node,
+    bool pre) const=0;
+
+  long current_unwinding=-1;
+};
+
+/// An abstract class representing an SSA unwinder of the whole program.
+class unwindert
+{
+public:
+  /// Creates local unwinders for each function operating in the given mode.
+  virtual void init(unwinder_modet mode)=0;
+
+  /// Runs initializing actions in all present local unwinders.
+  virtual void init_localunwinders()=0;
+
+  /// Unwinds all functions up to the given bound k.
+  virtual void unwind_all(unsigned k)=0;
+
+  /// Returns a local unwinder for the given function name.
+  virtual local_unwindert &get(const irep_idt &fname)=0;
+  /// Returns a const local unwinder for the given function name.
+  virtual const local_unwindert &get(const irep_idt &fname) const=0;
 };
 
 #endif

--- a/src/ssa/unwinder.h
+++ b/src/ssa/unwinder.h
@@ -1,0 +1,28 @@
+/*******************************************************************\
+
+Module: Unwinder
+
+Author: František Nečas
+
+\*******************************************************************/
+
+/// \file
+/// An interface of an SSA unwinder.
+
+#ifndef CPROVER_2LS_SSA_UNWINDER_H
+#define CPROVER_2LS_SSA_UNWINDER_H
+
+/// Represents the mode which an unwinder operates in.
+enum class unwinder_modet
+{
+  /// No specific behaviour requested, simply unwind.
+  NORMAL,
+  /// Bounded model checking is being performed. Add constraints
+  /// only in the base case.
+  BMC,
+  /// K-induction is being performed, add constraints and also hoisted
+  /// assertions.
+  K_INDUCTION,
+};
+
+#endif

--- a/src/ssa/unwinder.h
+++ b/src/ssa/unwinder.h
@@ -36,8 +36,9 @@ public:
   virtual void init()=0;
 
   /// Performs unwinding of all loops in the function up to bound k
-  /// \param The target unwind count which should be present after
+  /// \param k The target unwind count which should be present after
   ///   unwinding the loop.
+  /// \pre The unwinder has been initialized using \ref init
   virtual void unwind(unsigned k)=0;
 
   /// Gathers conditions under which loops continue.
@@ -55,6 +56,7 @@ public:
     const local_SSAt::nodet &node,
     bool pre) const=0;
 
+  /// The bound up to which loops are currently unwound.
   long current_unwinding=-1;
 };
 
@@ -63,17 +65,22 @@ class unwindert
 {
 public:
   /// Creates local unwinders for each function operating in the given mode.
+  /// \param mode Mode under which the unwinders should be initialized.
   virtual void init(unwinder_modet mode)=0;
 
   /// Runs initializing actions in all present local unwinders.
   virtual void init_localunwinders()=0;
 
   /// Unwinds all functions up to the given bound k.
+  /// \param k The target unwind count which should be present after
+  ///   unwinding the loop.
   virtual void unwind_all(unsigned k)=0;
 
   /// Returns a local unwinder for the given function name.
+  /// \param fname Name of the function to get the unwinder of.
   virtual local_unwindert &get(const irep_idt &fname)=0;
   /// Returns a const local unwinder for the given function name.
+  /// \param fname Name of the function to get the unwinder of.
   virtual const local_unwindert &get(const irep_idt &fname) const=0;
 };
 

--- a/src/ssa/unwinder.h
+++ b/src/ssa/unwinder.h
@@ -64,6 +64,8 @@ public:
 class unwindert
 {
 public:
+  virtual ~unwindert() = default;
+
   /// Creates local unwinders for each function operating in the given mode.
   /// \param mode Mode under which the unwinders should be initialized.
   virtual void init(unwinder_modet mode)=0;


### PR DESCRIPTION
This PR introduces a new unwinder which unwinds on GOTO level, makes necessary transformations (mainly related to dynamic object handling) and then computes a new SSA with correct points-to analysis. So far, we have not managed to integrate this solution with incremental SAT solving but this already shows promising results.

The GOTO unwinding itself is slower due to not making use of incremental SAT solver. To overcome this, the current implementation uses both the old unwinder (by default) and then the new unwinder only in cases where dynamic objects are used with unwinding (or k-induction). Such approach combines the best of both worlds -- it is sound when the old approach was not but it is quick where the overhead would not bring any advantages. This is achieved by the unwinders implementing a general interface.

Experiments show promising results so far, we've compared the old and new solution on a subset of SV-COMP benchmarks (most of reach-safety was included, the whole memsafety and part of termination) with a 5 minute timeout:

| Category     | Correct Tasks (old) | Incorrect Tasks (old) | Score (old) | Correct Tasks (new) | Incorrect Tasks (new) | Score (new) |
|--------------|---------------------|-----------------------|-------------|---------------------|-----------------------|-------------|
| reach-safety | 776                 | 2                     | 1331        | 814                 | 1                     | 1420        |
| memsafety    | 92                  | 3                     | 83          | 143                 | 6                     | 96          |
| termination  | 164                 | 0                     | 280         | 164                 | 0                     | 280         |

All of these improvements come from proper use of k-induction in benchmarks with dynamic memory. The 3 new failing tests in memsafety are a bit unfortunate, these are:
- memsafety-ext/tree_dsw
- memsafety-ext/tree_of_cslls
- list-ext3-properties/dll_circular_traversal

In order to make memory leak analysis sound with unwinding, I had to introduce a workaround which duplicates assignments to `__CPROVER_memory_leak` variable for each malloc/free. I initially expected that some of the new failing benchmarks will be caused by the same problem but with `__CPROVER_deallocated` so I tried implementing a "split" of this variable as well (present on `deallocated-fix` branch on my fork), however it introduced more incorrect results and slowed 2LS down significantly. I assume there will be differrent reasons for the 3 incorrect benchmarks, haven't figured it out just yet.

This PR also re-labels some of our old regression tests since they now work properly with the new unwinder and adds some new tests where the upsides of this solution are demonstrated.