### PR TITLE
Drop symbolic path domain

### DIFF
--- a/src/2ls/2ls_parse_options.cpp
+++ b/src/2ls/2ls_parse_options.cpp
@@ -408,12 +408,6 @@ int twols_parse_optionst::doit()
   if(get_goto_program(options))
     return 6;
 
-  if(cmdline.isset("heap") && dynamic_objects->have_objects())
-  {
-    // Only use sympath domain if dynamic memory is used
-    options.set_option("sympath", true);
-  }
-
   const namespacet ns(goto_model.symbol_table);
 
   if(cmdline.isset("show-stats"))

--- a/src/domains/heap_domain.h
+++ b/src/domains/heap_domain.h
@@ -30,7 +30,8 @@ public:
     replace_mapt &_renaming_map,
     const var_specst &var_specs,
     const local_SSAt &SSA):
-    simple_domaint(_domain_number, _renaming_map, SSA.ns)
+    simple_domaint(_domain_number, _renaming_map, SSA.ns),
+    dynamic_objects(SSA.dynamic_objects)
   {
     make_template(var_specs, ns);
   }
@@ -64,15 +65,20 @@ public:
     // Row is nondeterministic - row expression is TRUE
     bool nondet=false;
 
-    explicit row_valuet(const namespacet &ns):ns(ns) {}
+    explicit row_valuet(
+      const namespacet &ns,
+      const dynamic_objectst &dynamic_objects):
+      ns(ns), dynamic_objects(dynamic_objects) {}
 
     exprt get_row_expr(const template_row_exprt &templ_row_expr) const;
+    exprt ptr_equality(const exprt &ptr_expr, const exprt &ptr_value) const;
 
     bool add_points_to(const points_to_relt &destinations);
     bool set_nondet();
 
   protected:
     const namespacet &ns;
+    const dynamic_objectst &dynamic_objects;
   };
 
   // Heap value is a conjunction of rows
@@ -109,6 +115,8 @@ protected:
   const exprt get_points_to_dest(
     const exprt &solver_value,
     const exprt &templ_row_expr);
+
+  const dynamic_objectst &dynamic_objects;
 };
 
 #endif // CPROVER_2LS_DOMAINS_HEAP_DOMAIN_H

--- a/src/domains/template_generator_base.cpp
+++ b/src/domains/template_generator_base.cpp
@@ -57,6 +57,8 @@ void template_generator_baset::get_pre_post_guards(
   exprt pcond=SSA.cond_symbol(n_it->location);
   ssa_local_unwinder.unwinder_rename(to_symbol_expr(pcond), *n_it, false);
   post_guard=and_exprt(pguard, pcond);
+
+  post_renaming_map[lsguard]=pcond;
 }
 
 symbol_exprt template_generator_baset::get_pre_var(

--- a/src/ssa/dynamic_objects.h
+++ b/src/ssa/dynamic_objects.h
@@ -21,6 +21,8 @@ Author: Viktor Malik
 #include <string>
 #include <vector>
 
+class local_SSAt;
+
 class dynamic_objectt
 {
 public:
@@ -43,12 +45,14 @@ public:
 
   void set_alloc_guard(const exprt &guard) { alloc_guard=guard; }
   const exprt &get_alloc_guard() const { return alloc_guard; }
+  const exprt &get_loop_guard() const { return loop_guard; }
 
 private:
   symbolt symbol;
   const goto_programt::instructiont *loc;
   bool concrete;
 
+  exprt loop_guard=true_exprt();
   exprt alloc_guard=true_exprt();
 
   friend class dynamic_objectst;
@@ -72,6 +76,8 @@ public:
   const std::vector<dynamic_objectt> get_all_objects() const;
   const std::vector<dynamic_objectt> &get_objects(
     const goto_programt::instructiont &loc) const;
+  std::vector<dynamic_objectt> &get_objects(
+    const goto_programt::instructiont &loc);
   const dynamic_objectt *get_single_abstract_object(
     const goto_programt::instructiont &loc);
   const dynamic_objectt *get_object_by_name(const irep_idt &name) const;
@@ -84,6 +90,8 @@ public:
 
   void replace_malloc(bool with_concrete);
   void generate_instances(const optionst &options);
+
+  void set_loop_guards(const local_SSAt &SSA);
 
 private:
   typedef std::map<symbol_exprt, size_t> instance_countst;
@@ -123,6 +131,7 @@ private:
   // These are "state" variables used when parsing goto program
   goto_programt::instructiont *loop_end=nullptr;
   exprt malloc_size=nil_exprt();
+  exprt current_loop_guard=nil_exprt();
 
   goto_modelt &goto_model;
   const namespacet ns;

--- a/src/ssa/local_ssa.cpp
+++ b/src/ssa/local_ssa.cpp
@@ -63,6 +63,8 @@ void local_SSAt::build_SSA()
 
   // entry and exit variables
   get_entry_exit_vars();
+
+  dynamic_objects.set_loop_guards(*this);
 }
 
 void local_SSAt::get_entry_exit_vars()


### PR DESCRIPTION
Originally, symbolic paths were meant to handle the situation when a heap invariant containing addresses of dynamic objects would be used for cases when the dynamic objects were not allocated.

Thanks to the new dynamic object management class, this problem can be solved in a better way by adding a loop guard (guarding the object allocation) directly to the heap invariant. In particular, if a heap template row value contains a pointer-object equality (stating that the pointer may point to the object), this adds (conjuncts) a loop-select guard of the object allocation loop.

For example, if the original row value was e.g.:
```    
p#lb50 == &dynamic_object$16 || p#lb50 == &dynamic_object$32
``` 
where `dynamic_object$16` is allocated in a loop with `$guard#ls30` and `dynamic_object$32` is allocated in a loop with `$guard#ls50`, the new row value is:
```
(p#lb50 == &dynamic_object$16 && $guard#ls30) || (p#lb50 == &dynamic_object$32 && $guard#ls50)
```

This makes sure that invariants for the dynamic object are used only if the objects were actually allocated.

This new approach brings some considerable speedup, e.g. for the `heap-data` regression suite:
```
<master> $ time make test
real	0m48.871s
user	0m48.118s
sys	0m0.510s

<drop-sympath-domain> $ time make test
real	0m12.895s
user	0m12.416s
sys	0m0.352s
```
