### PR TITLE
Start using clang-format to format code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,81 @@
+---
+AccessModifierOffset: '-2'
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: 'false'
+AlignConsecutiveDeclarations: 'false'
+AlignEscapedNewlinesLeft: 'false'
+AlignOperands: 'true'
+AlignTrailingComments: 'true'
+AllowAllParametersOfDeclarationOnNextLine: 'false'
+AllowShortBlocksOnASingleLine: 'false'
+AllowShortCaseLabelsOnASingleLine: 'false'
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: 'false'
+AllowShortLoopsOnASingleLine: 'false'
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: 'true'
+AlwaysBreakTemplateDeclarations: 'true'
+BinPackArguments: 'false'
+BinPackParameters: 'false'
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: 'true'
+BreakConstructorInitializersBeforeComma: 'false'
+ColumnLimit: '80'
+ConstructorInitializerAllOnOneLineOrOnePerLine: 'true'
+ConstructorInitializerIndentWidth: '2'
+ContinuationIndentWidth: '2'
+Cpp11BracedListStyle: 'true'
+DerivePointerAlignment: 'false'
+DisableFormat: 'false'
+ExperimentalAutoDetectBinPacking: 'false'
+ForEachMacros: [
+  'forall_goto_program_instructions',
+  'Forall_goto_program_instructions',
+  'forall_operands',
+  'Forall_operands',
+  'forall_expr',
+  'Forall_expr']
+IndentCaseLabels: 'false'
+IndentPPDirectives: AfterHash
+IndentWidth: '2'
+IndentWrappedFunctionNames: 'false'
+KeepEmptyLinesAtTheStartOfBlocks: 'false'
+Language: Cpp
+MaxEmptyLinesToKeep: '1'
+NamespaceIndentation: None
+PenaltyBreakString: 10000
+PointerAlignment: Right
+ReflowComments: 'false'
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: '_class.h(>|")$'
+    Priority: 0
+  - Regex: '<util/'
+    Priority: 1
+  - Regex: '<goto-programs/'
+    Priority: 2
+  - Regex: '<.+/.+>'
+    Priority: 3
+  - Regex: '^"[^/]+"$'
+    Priority: 4
+  - Regex: '<[^/]+>'
+    Priority: 5
+SpaceAfterCStyleCast: 'false'
+SpaceBeforeAssignmentOperators: 'true'
+SpaceBeforeParens: Never
+SpaceInEmptyParentheses: 'false'
+SpacesBeforeTrailingComments: '1'
+SpacesInAngles: 'false'
+SpacesInCStyleCastParentheses: 'false'
+SpacesInContainerLiterals: 'false'
+SpacesInParentheses: 'false'
+SpacesInSquareBrackets: 'false'
+Standard: c++11
+TabWidth: '2'
+UseTab: Never
+---
+Language: Java
+ColumnLimit: '80'
+DisableFormat: 'true'
+...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,15 @@ jobs:
     if: github.ref != 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2
+      - name: Install clang-format
+        run: sudo apt-get install clang-format
+      - name: Install git-clang-format
+        run: |
+          wget https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/git-clang-format
+          sudo install -t /usr/bin git-clang-format
       - name: Get the latest master
         run: git fetch origin master:master
-      - name: Run lint
-        run: scripts/run_lint.sh master HEAD
+      - name: Run clang-format
+        run: git clang-format master
+      - name: Diff
+        run: git diff --exit-code

--- a/regression/.clang-format
+++ b/regression/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: false

--- a/src/2ls/2ls_parse_options.cpp
+++ b/src/2ls/2ls_parse_options.cpp
@@ -1482,6 +1482,7 @@ void twols_parse_optionst::report_unknown()
   }
 }
 
+// clang-format off
 /// display command line help
 void twols_parse_optionst::help()
 {

--- a/src/2ls/2ls_parse_options.h
+++ b/src/2ls/2ls_parse_options.h
@@ -24,6 +24,7 @@ class optionst;
 
 #include "summary_checker_base.h"
 
+// clang-format off
 #define TWOLS_OPTIONS \
   "(xml-ui)" \
   "(function):" \
@@ -67,6 +68,7 @@ class optionst;
   "(competition-mode)(slice)(no-propagation)(independent-properties)" \
   "(no-unwinding-assertions)"
   // the last line is for CBMC-regression testing only
+// clang-format on
 
 class twols_parse_optionst:
   public parse_options_baset,


### PR DESCRIPTION
Using `.clang-format` from CBMC with one tweak:
- `AlignAfterOpenBracket` is set to `Align` (instead of `AlwaysBreak`) as the old option would put a break after the opening bracket in a multiline if, which looks ugly

The formatting is turned off for regression tests, help, and CLI options list.

Instead of reformatting the entire codebase with `clang-format`, we use the `git-clang-format` tool to run the checks on changed lines only for each PR.

I've tested this on the array work which I'll post in a following PR, with the new style. At the moment, it's in my [arrays](https://github.com/viktormalik/2ls/tree/arrays) branch (to preview the new style).

Closes #165.