### PR TITLE
Fix GOTO undinwing of dynamic objects

### DIFF
--- a/regression/heap/sll_circular_traversal/main.c
+++ b/regression/heap/sll_circular_traversal/main.c
@@ -1,0 +1,96 @@
+// This example is taken from the SV-COMP benchmarks:
+// https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks/-/blob/main/c/list-ext3-properties/sll_circular_traversal-1.c
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+extern void abort(void);
+#include <assert.h>
+void reach_error() { assert(0); }
+/*
+ * SLL circular traversal example:
+ * Build circular sll (1-1-1-1-1).
+ * Check and overwrite data to (1-2-3-4-5).
+ * Directly continue the traversal, check data and deallocate.
+ */
+#include <stdlib.h>
+
+typedef struct node {
+  struct node* next;
+  int data;
+} *SLL;
+
+void myexit(int s) {
+ _EXIT: goto _EXIT;
+}
+
+SLL sll_circular_create(int len, int data) {
+  SLL const last = (SLL) malloc(sizeof(struct node));
+  if(NULL == last){
+    myexit(1);
+  }
+  last->next = last;
+  last->data = data;
+  SLL head = last;
+  while(len > 1) {
+    SLL new_head = (SLL) malloc(sizeof(struct node));
+    if(NULL == new_head){
+      myexit(1);
+    }
+    new_head->next = head;
+    new_head->data = data;
+    head = new_head;
+    len--;
+  }
+  last->next = head;
+  return head;
+}
+
+int main() {
+  const int len = 5;
+  const int data_init = 1;
+  SLL const head = sll_circular_create(len, data_init);
+  /* first traversal */
+  int data_new = 1;
+  SLL ptr = head;
+  do {
+    if(data_init != ptr->data) {
+      goto ERROR;
+    }
+    ptr->data = data_new;
+    ptr = ptr->next;
+    data_new++;
+  } while(ptr != head);
+  /* second traversal */
+  data_new = data_new - len;
+  do {
+    if(data_new != ptr->data) {
+      goto ERROR;
+    }
+    SLL temp = ptr->next;
+    if (ptr != head) {
+        free(ptr);
+    }
+    ptr = temp;
+    data_new++;
+  } while(ptr != head);
+  free(head);
+  return 0;
+ ERROR: {reach_error();abort();}
+  return 1;
+}
+

--- a/regression/heap/sll_circular_traversal/test.desc
+++ b/regression/heap/sll_circular_traversal/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--heap --intervals --havoc --unwind 4
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$

--- a/src/ssa/goto_unwinder.cpp
+++ b/src/ssa/goto_unwinder.cpp
@@ -152,14 +152,11 @@ void goto_local_unwindert::rename_dynamic_objects()
   std::map<std::string, std::string> rename_map;
   for(auto &i_it : goto_function.body.instructions)
   {
-    if(i_it.is_assign())
+    if(i_it.is_assign() && i_it.code().get_bool("#malloc"))
     {
       exprt &assign = i_it.assign_rhs_nonconst();
-      if(dynamic_objects.have_objects(i_it))
-      {
-        dynamic_objects.clear(i_it);
-        rename_dynamic_objects_rec(i_it, assign, rename_map);
-      }
+      dynamic_objects.clear(i_it);
+      rename_dynamic_objects_rec(i_it, assign, rename_map);
     }
   }
 }
@@ -224,6 +221,8 @@ void goto_local_unwindert::unwind_function(
   for(auto i_it=goto_function.body.instructions.begin();
       i_it!=goto_function.body.instructions.end();)
   {
+    if(dynamic_objects.have_objects(*i_it))
+      i_it->code_nonconst().set("#malloc", true);
     // The new unwinds will be inserted between the existing ones and the
     // loop, update the existing unwind flags.
     int unwind_flag_value=i_it->code().get_int(unwind_flag);


### PR DESCRIPTION
Commit 89e30e27 replaced usage of the `#malloc_result` property by querying the dynamic objects database. This is not sufficient for the GOTO unwinder since it used to use that property to locate the cloned malloc instruction (already containing the generated dynamic objects). As the GOTO unwinder does not duplicate entries in the dynamic objects database, the malloc location is now not identified properly.

This fixes the above problem by introducing a `#malloc` property, local to the unwinder, which we use to mark the malloc result instruction prior to running the CBMC unwinder. Since properties are cloned during unwinding, we can use it to locate the new malloc instruction and properly generate new dynamic objects.

Add test from SV-COMP which contains a linked list of a fixed length, so can be verified with sufficient unwinding without computing invariants.