### PR TITLE
Fix bug in reusing symbolic dereferences

### DIFF
--- a/regression/heap/symderef_reuse/main.c
+++ b/regression/heap/symderef_reuse/main.c
@@ -1,0 +1,25 @@
+#include <stdlib.h>
+
+struct node {
+    int data;
+    struct node *next;
+};
+
+int main()
+{
+    struct node *first = malloc(sizeof(*first));
+    struct node *second = malloc(sizeof(*first));
+    first->data = 0;
+    second->data = 1;
+    first->next = second;
+    second->next = NULL;
+
+    for (int i = 0; i < 2; i++)
+    {
+        struct node *n = first;
+        for (int j = i; j > 0; j--)
+            n = n->next;
+        int data = n->data;
+        assert(data == i);
+    }
+}

--- a/regression/heap/symderef_reuse/test.desc
+++ b/regression/heap/symderef_reuse/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--havoc --unwind 2
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$

--- a/src/ssa/local_ssa.cpp
+++ b/src/ssa/local_ssa.cpp
@@ -1527,8 +1527,8 @@ bool local_SSAt::can_reuse_symderef(
 
   // If the pointer that is dereferenced was overwritten, the symbolic deref
   // is not valid.
-  if(pointer_def.is_assignment() && pointer_def.loc->location_number>=
-                                    symbolic_def.loc->location_number)
+  if((pointer_def.is_assignment() || pointer_def.is_phi()) &&
+     pointer_def.loc->location_number >= symbolic_def.loc->location_number)
     return false;
 
   // Search all aliasing objects (objects potentially pointed by the pointer)


### PR DESCRIPTION
We allow to reuse symbolic dereference objects to increase precision of the verification. One of the conditions for the reuse is that the dereferenced pointer must not have been overridden from the point of the last symbolic deref definition.

This condition contains a bug, though, as it assumed that the last definition is always an assignment. With unwinding in place, it can also be a phi instruction, so this commit adds that possibility.

Contains also a reproducer regression test.