### PR TITLE
Support arrays with standard invariants

### DIFF
--- a/src/domains/array_domain.cpp
+++ b/src/domains/array_domain.cpp
@@ -40,8 +40,8 @@ array_domaint::array_domaint(unsigned int domain_number,
   // representing one segment.
   make_segments(var_specs, SSA.ns);
   auto segment_var_specs = var_specs_from_segments();
-  inner_domain =
-    template_generator.instantiate_standard_domains(segment_var_specs, SSA);
+  inner_domain = template_generator.instantiate_standard_domains(
+    segment_var_specs, SSA, &renaming_map);
 
   // For the zones domain, add some custom template rows for differences among
   // segments and scalars

--- a/src/domains/strategy_solver_binsearch.cpp
+++ b/src/domains/strategy_solver_binsearch.cpp
@@ -38,6 +38,7 @@ bool strategy_solver_binsearcht::iterate(invariantt &_inv)
 
   exprt::operandst strategy_cond_exprs;
   tpolyhedra_domain.make_not_post_constraints(inv, strategy_cond_exprs);
+  exprt post = disjunction(strategy_cond_exprs);
 
   tpolyhedra_domain.strategy_cond_literals.resize(strategy_cond_exprs.size());
 

--- a/src/domains/template_generator_base.cpp
+++ b/src/domains/template_generator_base.cpp
@@ -308,7 +308,7 @@ void template_generator_baset::add_var(const vart &var,
                                        var_specst &var_specs)
 {
   exprt aux_expr=true_exprt();
-  if(std_invariants && pre_guard.id()==ID_and)
+  if(std_invariants && var.type().id() != ID_array && pre_guard.id() == ID_and)
   {
     const and_exprt &pre_guard_and=to_and_expr(pre_guard);
     exprt init_guard=and_exprt(
@@ -592,10 +592,12 @@ bool template_generator_baset::instantiate_custom_templates(
 
 std::unique_ptr<domaint> template_generator_baset::instantiate_standard_domains(
   const var_specst &var_specs,
-  const local_SSAt &SSA)
+  const local_SSAt &SSA,
+  replace_mapt *renaming_map_)
 {
-  replace_mapt &renaming_map=
-    std_invariants ? aux_renaming_map : post_renaming_map;
+  replace_mapt &renaming_map =
+    renaming_map_ ? *renaming_map_
+                  : std_invariants ? aux_renaming_map : post_renaming_map;
 
   domain_vect domains;
   // get domains from command line options
@@ -620,7 +622,7 @@ std::unique_ptr<domaint> template_generator_baset::instantiate_standard_domains(
     auto array_var_specs = filter_array_domain(var_specs);
     if(!array_var_specs.empty())
       domains.emplace_back(new array_domaint(domain_number++,
-                                             renaming_map,
+                                             post_renaming_map,
                                              init_renaming_map,
                                              array_var_specs,
                                              SSA,

--- a/src/domains/template_generator_base.h
+++ b/src/domains/template_generator_base.h
@@ -153,7 +153,8 @@ protected:
   virtual void handle_special_functions(const local_SSAt &SSA);
   std::unique_ptr<domaint>
   instantiate_standard_domains(const var_specst &var_specs_,
-                               const local_SSAt &SSA);
+                               const local_SSAt &SSA,
+                               replace_mapt *renaming_map_ = nullptr);
   bool instantiate_custom_templates(const local_SSAt &SSA);
 
   void rename_aux_post(symbol_exprt &expr)


### PR DESCRIPTION
When `--std-invariants` is set, invariants are computed for the loop head (i.e. contain the pre-loop value in addition to the loop-back values). This is not convenient for arrays since they are typically uninitialized and only get initialized inside a loop. Including the pre-loop array value would add the nondet value to the invariant, making the entire invariant (especially the one for the initializer loop) nondet.

This change prohibits usage of standard invariants for the array domain. Most of the changes are done in the template generator which:
- does not generate aux_expr for array var specs,
- always passes post_renaming_map (instead of aux_renaming_map) to the array domain and its inner domains.

This is especially necessary for SV-COMP where we use `--k-induction` which sets `--std-invariants`, too.